### PR TITLE
crypto-es　を最新に更新

### DIFF
--- a/packages-kintone-customize/app-229-contracts/package.json
+++ b/packages-kintone-customize/app-229-contracts/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "api-chatwork": "*",
     "api-kintone": "*",
-    "crypto-es": "^1.2.7",
+    "crypto-es": "^2.1.0",
     "dompurify": "^3.0.5",
     "jest": "^29.6.4",
     "jquery": "^3.7.1",


### PR DESCRIPTION
## 変更

1. 件名通り

## 理由

1. https://github.com/cocosumo/yumecoco-monorepo/security/dependabot/38

## 備考

契約一覧に関わるもので、ビルド不要。
セキュリティ警告への対策のみ。