### PR TITLE
1082-通知したリマインダーレコードの更新処理を実装する

### DIFF
--- a/packages-automation/auto-unissuedInvoiceReminder/src/sections/updateReminders/convertReminderToKintone.test.ts
+++ b/packages-automation/auto-unissuedInvoiceReminder/src/sections/updateReminders/convertReminderToKintone.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from '@jest/globals';
+import path from 'path';
+import fs from 'fs';
+import { IUnissuedinvoicealert } from 'types';
+import { convertReminderToKintone } from './convertReminderToKintone';
+import format from 'date-fns/format';
+import addWeeks from 'date-fns/addWeeks';
+
+
+
+describe('convertReminderToKintone', () => {
+  // set output file of getRemindersScheduledForToday.test.ts
+  const remindersPath = path.join(__dirname, '../__TEST__/reminders.json');
+  const remindersDat = JSON.parse(fs.readFileSync(remindersPath, 'utf8')) as IUnissuedinvoicealert[];
+
+  it('本日通知対象の更新レコードを準備する', () => {
+
+    const result = convertReminderToKintone({
+      recReminders: [remindersDat[0]],
+    })[0];
+
+    const updateId = remindersDat[0].$id.value;
+    const todayStr = format(new Date(), 'yyyy-MM-dd');
+    const dateOneWeekLater = format(addWeeks(new Date(), 1), 'yyyy-MM-dd');
+
+
+    expect(result.id).toBe(updateId);
+    expect(result.record?.lastAlertDate?.value).toBe(todayStr);
+    expect(result.record?.scheduledAlertDate?.value).toBe(dateOneWeekLater);
+
+  }, 10000);
+
+});

--- a/packages-automation/auto-unissuedInvoiceReminder/src/sections/updateReminders/convertReminderToKintone.ts
+++ b/packages-automation/auto-unissuedInvoiceReminder/src/sections/updateReminders/convertReminderToKintone.ts
@@ -1,0 +1,28 @@
+import { UpdateUnissuedInvAlertId } from 'api-kintone/src/unissuedInvoiceAlert/updateUnissuedInvoiceAlert';
+import addWeeks from 'date-fns/addWeeks';
+import format from 'date-fns/format';
+import { IUnissuedinvoicealert } from 'types';
+
+
+
+export const convertReminderToKintone = ({
+  recReminders,
+}: {
+  recReminders: IUnissuedinvoicealert[]
+}) => {
+
+  const updateRecords: UpdateUnissuedInvAlertId[] = recReminders.map(({
+    $id,
+  }) => {
+    return ({
+      id: $id.value,
+      record: {
+        lastAlertDate: { value: format(new Date(), 'yyyy-MM-dd') },
+        scheduledAlertDate: { value: format(addWeeks(new Date(), 1), 'yyyy-MM-dd') },
+      },
+    });
+  });
+
+  return updateRecords;
+
+};

--- a/packages-automation/auto-unissuedInvoiceReminder/src/sections/updateReminders/updateReminders.test.ts
+++ b/packages-automation/auto-unissuedInvoiceReminder/src/sections/updateReminders/updateReminders.test.ts
@@ -1,0 +1,24 @@
+import { describe, it } from '@jest/globals';
+import path from 'path';
+import fs from 'fs';
+import { IUnissuedinvoicealert } from 'types';
+import { updateReminders } from './updateReminders';
+
+
+
+describe('updateReminders', () => {
+  // set output file of getRemindersScheduledForToday.test.ts
+  const remindersPath = path.join(__dirname, '../__TEST__/reminders.json');
+  const remindersDat = JSON.parse(fs.readFileSync(remindersPath, 'utf8')) as IUnissuedinvoicealert[];
+
+  it('本日通知対象のレコードを更新する', async () => {
+
+    await updateReminders({
+      recReminders: [remindersDat[0]],
+    });
+
+    console.log(`レコードID=${remindersDat[0].$id.value} をkintoneアプリにてご確認ください`);
+
+  }, 10000);
+
+});

--- a/packages-automation/auto-unissuedInvoiceReminder/src/sections/updateReminders/updateReminders.ts
+++ b/packages-automation/auto-unissuedInvoiceReminder/src/sections/updateReminders/updateReminders.ts
@@ -1,0 +1,17 @@
+import { IUnissuedinvoicealert } from 'types';
+import { updateUnissuedInvoiceAlert } from 'api-kintone/src/unissuedInvoiceAlert/updateUnissuedInvoiceAlert';
+import { convertReminderToKintone } from './convertReminderToKintone';
+
+
+/** 通知済みのリマインダーレコードを更新する */
+export const updateReminders = async ({
+  recReminders,
+}: {
+  recReminders: IUnissuedinvoicealert[]
+}) => {
+
+  const updateRecords = convertReminderToKintone({ recReminders });
+
+  await updateUnissuedInvoiceAlert(updateRecords);
+
+};

--- a/packages-automation/auto-unissuedInvoiceReminder/src/unissuedInvoiceReminders.ts
+++ b/packages-automation/auto-unissuedInvoiceReminder/src/unissuedInvoiceReminders.ts
@@ -1,6 +1,7 @@
 import { getEmployees } from 'api-kintone';
 import { getRemindersScheduledForToday } from './sections/getRemindersScheduledForToday';
 import { notifyReminderToChatwork } from './sections/notifyReminderToChatwork/notifyReminderToChatwork';
+import { updateReminders } from './sections/updateReminders/updateReminders';
 
 
 
@@ -23,8 +24,7 @@ export const unissuedInvoiceReminders = async () => {
     recEmployees,
   });
 
-
-  // リマインダーレコードの更新処理
+  await updateReminders({ recReminders });
 
 
   console.log('finish unissued invoice reminder');

--- a/packages/api-kintone/src/unissuedInvoiceAlert/updateUnissuedInvoiceAlert.ts
+++ b/packages/api-kintone/src/unissuedInvoiceAlert/updateUnissuedInvoiceAlert.ts
@@ -1,0 +1,31 @@
+import { RecordID, Revision, UpdateKey } from '@kintone/rest-api-client/lib/src/client/types';
+import { updateRecords } from 'api-kintone';
+import { IUnissuedinvoicealert } from 'types';
+import { appId } from './config';
+
+
+export type UpdateUnissuedInvAlertId = {
+  id: RecordID
+  record?: Partial<IUnissuedinvoicealert> | undefined
+  revision?: Revision | undefined
+};
+
+export type UpdateUnissuedInvAlertUDKey = {
+  updateKey: UpdateKey
+  record?: Partial<IUnissuedinvoicealert> | undefined
+  revision?: Revision | undefined
+};
+export type UpdateUnissuedInvAlert = UpdateUnissuedInvAlertId | UpdateUnissuedInvAlertUDKey;
+
+
+/**
+ * 請求書発行アラートレコードを一括更新する
+ */
+export const updateUnissuedInvoiceAlert = (params: UpdateUnissuedInvAlert[]) => {
+
+  return updateRecords({
+    records: params,
+    app: appId,
+  });
+
+};


### PR DESCRIPTION
## 変更

1. タイトルのとおり

## 理由

1. closes #1082 

## テスト

- convertReminderToKintone.test.tsの実行
- updateReminders.test.tsの実行
- npm run start:dev の実行(結合テスト)
