### PR TITLE
fix-1088-bug-顧客管理から見積タブを開いたらラグが発生します

### DIFF
--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/estimatesDetails/EstimateActions.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/estimatesDetails/EstimateActions.tsx
@@ -1,0 +1,52 @@
+import { Stack } from '@mui/material';
+import { ContractButton } from '../common/ContractButton';
+import { ExportButton } from './ExportButton';
+import { NewButton } from '../common/NewButton';
+import { generateParams } from 'kokoas-client/src/helpers/url';
+import { EditButton } from '../common/EditButton';
+import { pages } from 'kokoas-client/src/pages/Router';
+
+export const EstimateActions = ({
+  projEstimateId,
+  projId,
+}:{
+  projEstimateId: string | undefined,
+  projId: string
+}) => {
+  return (
+    <Stack 
+      spacing={2} 
+      direction={'row'}
+      justifyContent={'flex-end'}
+    >
+          
+
+      {projEstimateId && (
+      <>
+        <ContractButton
+          href={`${pages.projContractPreviewV2}?${generateParams({ projEstimateId })}`}
+          title='見積を利用して契約を作成する。'
+        />
+
+        <ExportButton
+          projEstimateId={projEstimateId}
+        />
+      </>
+
+      )}
+
+      <NewButton 
+        href={`${pages.projEstimate}?${generateParams({ projId })}`}
+        title='見積を作成する'
+      />
+          
+      {projEstimateId && (
+      <EditButton 
+        href={`${pages.projEstimate}?${generateParams({ projEstimateId })}`}
+        title='見積を編集する'
+      />
+      )}
+    
+    </Stack>
+  );
+};

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/estimatesDetails/EstimateContent.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/estimatesDetails/EstimateContent.tsx
@@ -17,79 +17,31 @@ export const EstimateContent = (props: Partial<EstTableProps> & {
     record,
     results,
     summary,
-    projId,
     emptyNode,
   } = props;
-
-  const {
-    uuid: projEstimateId,
-  } = record ?? {};
 
 
 
   return (
-    <Box 
-      height={'100%'}
-      width={'100%'} 
-      py={2}
-      pr={2}
-      sx={{
-        overflowY: 'scroll',
-      }}
-    >
-      <Stack spacing={2}>
-
-        <Stack 
-          spacing={2} 
-          direction={'row'}
-          justifyContent={'flex-end'}
-        >
-          
-
-          {projEstimateId?.value && (
-            <>
-              <ContractButton
-                href={`${pages.projContractPreviewV2}?${generateParams({ projEstimateId: projEstimateId.value })}`}
-                title='見積を利用して契約を作成する。'
-              />
-
-              <ExportButton
-                projEstimateId={projEstimateId.value}
-              />
-            </>
-
-          )}
-
-          <NewButton 
-            href={`${pages.projEstimate}?${generateParams({ projId })}`}
-            title='見積を作成する'
-          />
-          
-          {projEstimateId?.value && (
-          <EditButton 
-            href={`${pages.projEstimate}?${generateParams({ projEstimateId: projEstimateId?.value })}`}
-            title='見積を編集する'
-          />
-          )}
+    <>
     
-        </Stack>
-     
-        {record && results && summary && (
+
+      {record && results && summary && (
         <EstimatesTable 
           record={record}
           results={results}
           summary={summary}
         />
-        )}
+      )}
 
-        {emptyNode}
+      {emptyNode}
 
  
-        {record && (
+      {record && (
         <OtherInfo record={record}  />
-        )}
+      )}
 
-      </Stack>
-    </Box>
+
+    </>
   );
 };

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/estimatesDetails/EstimatesDetails.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/estimatesDetails/EstimatesDetails.tsx
@@ -1,9 +1,11 @@
-import { LinearProgress, Stack } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import { BranchList } from './BranchList';
 import { EstimateContent } from './EstimateContent';
 import { useEstimatesByProjId } from 'kokoas-client/src/hooksQuery';
 import { useState } from 'react';
 import { EmptyBox } from 'kokoas-client/src/components';
+import { Loading } from 'kokoas-client/src/components/ui/loading/Loading';
+import { EstimateActions } from './EstimateActions';
 
 export const EstimatesDetails = ({
   projId,
@@ -29,7 +31,9 @@ export const EstimatesDetails = ({
     setSelectedEstIdx(idx);
   };
 
-  
+  const {
+    uuid: projEstimateId,
+  } = selectedRecord ?? {};  
 
   return (
 
@@ -46,24 +50,52 @@ export const EstimatesDetails = ({
         selectedIndex={selectedEstIdx}
         projId={projId}
       />
-     
-      {isLoading && <LinearProgress />}
 
-      {!isLoading && (
-      <EstimateContent 
-        record={selectedRecord}
-        results={selectedRecordCal}
-        summary={selectedRecordSummary}
-        projId={projId}
-        emptyNode={!records?.length && (
-          <EmptyBox>
-            見積もりがありません
-          </EmptyBox>
-        )}
-      />
-      )}
+
+      <Box 
+        height={'100%'}
+        width={'100%'} 
+        py={2}
+        pr={2}
+        sx={{
+          overflowY: 'scroll',
+        }}
+      >
+
+        <Stack spacing={2}>
+          <EstimateActions 
+            projEstimateId={projEstimateId?.value}
+            projId={projId}
+          />
+
+          {isLoading && (
+          <Stack
+            justifyContent={'center'}
+            alignItems={'center'}
+            width={'100%'}
+          >
+            <Loading />
+          </Stack>)}
+
+          {!isLoading && (
+          <EstimateContent 
+            record={selectedRecord}
+            results={selectedRecordCal}
+            summary={selectedRecordSummary}
+            projId={projId}
+            emptyNode={!records?.length && (
+            <EmptyBox>
+              見積もりがありません
+            </EmptyBox>
+            )}
+          />
+          )}
+        </Stack>
+
+      </Box>
 
     </Stack>
+    
 
 
   );


### PR DESCRIPTION
## 変更前

![image](https://github.com/cocosumo/yumecoco-monorepo/assets/2501255/791e522a-2d80-4197-a175-6bb5e7a2e3c1)


## 変更後

![image](https://github.com/cocosumo/yumecoco-monorepo/assets/2501255/968bd91c-4ad3-428f-a879-8fdd4f4e61d7)


## 理由

1. closes #1088 
