### PR TITLE
fix-1094-単位が選べない空のプルダウンが表示されてしまう

### DIFF
--- a/packages/kokoas-client/src/hooksQuery/useUnits.ts
+++ b/packages/kokoas-client/src/hooksQuery/useUnits.ts
@@ -7,7 +7,7 @@ type GetAllUnitsReturn = Awaited<ReturnType<typeof getAllUnits>>;
 export const useUnits = <K = GetAllUnitsReturn>(
   select?: (data: GetAllUnitsReturn) => K) => {
   return useQuery(
-    [AppIds.stores],
+    [AppIds.units, 'getAllUnits'],
     getAllUnits,
     { 
       select, 

--- a/packages/kokoas-client/src/pages/projEstimate/estimateDataGrid/renderers/renderUnits.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/estimateDataGrid/renderers/renderUnits.tsx
@@ -12,16 +12,19 @@ const UnitsSelect = ({
 }: RenderEditCellProps<RowItem>) => {
   const [open, setOpen] = useState(true);
   const { data } = useUnits((u) => {
-    return u.map(({
+    return u?.map(({
       unit,
     }) => ({
       value: unit.value,
     }));
   });
 
+  // Prevent warning from MUI Select #https://github.com/mui/material-ui/issues/18494#issuecomment-782779777
+  if (!data) return null; 
+
   return (
     <Select
-      value={row.unit || undefined}
+      value={row.unit || ''}
       onChange={(event) => onRowChange({ ...row, unit: event.target.value }, true)}
       autoFocus
       size='small'


### PR DESCRIPTION
## 変更

1. 件名通り

## 理由

1. closes #1094 
