### PR TITLE
1096-補助金アラートに入金日の入力フィールドを追加する

### DIFF
--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/AlertContent.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/AlertContent.tsx
@@ -1,35 +1,89 @@
 import { Stack, Typography } from '@mui/material';
 import { KAlertPurpose, alertMessages } from './alertConfig';
+import { useMemo, useState } from 'react';
+import { JADatePicker } from 'kokoas-client/src/components';
+import format from 'date-fns/format';
+
 
 export const AlertContent = ({
   purpose,
 }: {
   purpose: KAlertPurpose
 }) => {
+  const [paymentDate, setPaymentDate] = useState<Date | undefined>(undefined);
 
+  const handleChange = (value: Date) => {
+    setPaymentDate(value);
+  };
+
+  const explanation = useMemo(() => {
+    const defaultMessage = alertMessages[purpose];
+    if (purpose === 'unissued') return defaultMessage;
+
+    if (!paymentDate) return defaultMessage;
+
+    const displayDate = format(paymentDate, 'yyyy/MM/dd');
+
+    return `${displayDate}に${defaultMessage}`;
+
+  }, [paymentDate, purpose]);
 
   return (
-    <Stack 
-      direction={'column'}
+    <Stack
+      direction={'row'}
       spacing={1}
     >
-      <Typography
-        variant='body2'
-        sx={{
-          color: 'gray',
-        }}
-      >
-        通知内容 :
-      </Typography>
+      {purpose === 'subsidy' &&
+        <Stack
+          direction={'column'}
+          spacing={1}
+        >
+          <Typography
+            variant='body2'
+            sx={{
+              color: 'gray',
+            }}
+          >
+            入金予定日 :
+          </Typography>
 
-      <Typography
-        variant='body1'
-        sx={{
-          pl: '10px',
-        }}
+          <JADatePicker
+            onChange={handleChange}
+            value={paymentDate}
+            slotProps={{
+              textField: {
+                label: '入金予定日',
+                size: 'small',
+                sx: {
+                  width: 150,
+                },
+              },
+            }}
+          />
+        </Stack>}
+
+      <Stack
+        direction={'column'}
+        spacing={1}
       >
-        {alertMessages[purpose]}
-      </Typography>
-    </Stack>
+        <Typography
+          variant='body2'
+          sx={{
+            color: 'gray',
+          }}
+        >
+          通知内容 :
+        </Typography>
+
+        <Typography
+          variant='body1'
+          sx={{
+            pl: '10px',
+          }}
+        >
+          {explanation}
+        </Typography>
+      </Stack>
+    </Stack >
   );
 };

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/AlertContent.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/AlertContent.tsx
@@ -1,21 +1,19 @@
 import { Stack, Typography } from '@mui/material';
 import { KAlertPurpose, alertMessages } from './alertConfig';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { JADatePicker } from 'kokoas-client/src/components';
 import format from 'date-fns/format';
 
 
 export const AlertContent = ({
   purpose,
+  paymentDate,
+  handleDateChange,
 }: {
   purpose: KAlertPurpose
+  paymentDate: Date | null
+  handleDateChange: (v: Date) => void
 }) => {
-  const [paymentDate, setPaymentDate] = useState<Date | null>(null);
-
-  const handleChange = (value: Date) => {
-    setPaymentDate(value);
-  };
-
   const explanation = useMemo(() => {
     const defaultMessage = alertMessages[purpose];
     if (purpose === 'unissued') return defaultMessage;
@@ -48,7 +46,7 @@ export const AlertContent = ({
           </Typography>
 
           <JADatePicker
-            onChange={handleChange}
+            onChange={handleDateChange}
             value={paymentDate}
             slotProps={{
               textField: {

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/AlertContent.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/AlertContent.tsx
@@ -10,7 +10,7 @@ export const AlertContent = ({
 }: {
   purpose: KAlertPurpose
 }) => {
-  const [paymentDate, setPaymentDate] = useState<Date | undefined>(undefined);
+  const [paymentDate, setPaymentDate] = useState<Date | null>(null);
 
   const handleChange = (value: Date) => {
     setPaymentDate(value);

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/AlertDialog.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/AlertDialog.tsx
@@ -19,7 +19,13 @@ export const AlertDialog = ({
   handleClose: () => void
   projId: string
 }) => {
-  const [purpose, setPurpose] = useState('unissued' as KAlertPurpose);
+  const [purpose, setPurpose] = useState('unissued' as KAlertPurpose);  
+  const [paymentDate, setPaymentDate] = useState<Date | null>(null);
+
+  const handleDateChange = (value: Date) => {
+    setPaymentDate(value);
+  };
+
 
   const recUnissuedInvReminders = useActiveUnissuedInvRemindersByProjId(projId);
 
@@ -81,7 +87,9 @@ export const AlertDialog = ({
       <AlertDialogContent
         purpose={purpose}
         handlePurposeChange={handlePurposeChange}
+        handleDateChange={handleDateChange}
         projId={projId}
+        paymentDate={paymentDate}
       />
 
       <DialogCloseButton handleClose={handleClose} />

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/AlertDialogContent.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/AlertDialogContent.tsx
@@ -9,11 +9,15 @@ import { useProjById } from 'kokoas-client/src/hooksQuery';
 export const AlertDialogContent = ({
   purpose,
   handlePurposeChange,
+  handleDateChange,
   projId,
+  paymentDate,
 }: {
   purpose: KAlertPurpose
   handlePurposeChange: (e: ChangeEvent<HTMLInputElement>, value: KAlertPurpose) => void
+  handleDateChange: (v: Date) => void
   projId: string
+  paymentDate: Date | null
 }) => {
 
   const { data: recProj } = useProjById(projId);
@@ -37,7 +41,11 @@ export const AlertDialogContent = ({
           handleChange={handlePurposeChange}
         />
 
-        <AlertContent purpose={purpose} />
+        <AlertContent
+          purpose={purpose}
+          handleDateChange={handleDateChange}
+          paymentDate={paymentDate}
+        />
 
         <AlertTarget agents={recProj?.agents} />
 

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/alertConfig.ts
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/alertConfig.ts
@@ -12,7 +12,7 @@ type AlertMessages = {
 
 export const alertMessages: AlertMessages = {
   'unissued': '顧客からの入金がありましたが、請求書が発行されていません。',
-  'subsidy': '補助金の請求書が必要です。',
+  'subsidy': '補助金の入金予定があります。',
 };
 
 


### PR DESCRIPTION
## 変更

1. タイトルの通り
2. ダイアログのメッセージにも入金日の情報を追記します。

## 理由

1. closes #1096 

## テスト

- ブラウザにて確認
