### PR TITLE
1103 feat サーバステータスが分かるものを追加する

### DIFF
--- a/packages/kokoas-client/src/api/others/checkServer.test.ts
+++ b/packages/kokoas-client/src/api/others/checkServer.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import * as config from 'config';
+
+
+
+describe('checkServer', () => {
+  beforeEach(() => {
+    jest.resetModules(); // prevent import caching
+  });
+
+  it('should return true for valid server url', async () => {
+    jest.doMock('config', () => ({
+      baseUrl: config.baseUrl,
+    }));
+    const { checkServer } = require('./checkServer');
+
+    // 環境の該当のサーバが動いていることが前提
+    const result = await checkServer();
+    console.log('result', result);
+    expect(result.alive).toBe(true);
+  });
+
+
+
+  it('should return false for non-existent server', async () => {
+    jest.doMock('config', () => ({
+      baseUrl: 'http://mockedurl.com',
+    }));
+    const { checkServer } = require('./checkServer');
+
+    const result = await checkServer();
+    console.log('result', result);
+    expect(result.alive).toBe(false);
+  });
+
+
+});

--- a/packages/kokoas-client/src/api/others/checkServer.ts
+++ b/packages/kokoas-client/src/api/others/checkServer.ts
@@ -1,0 +1,35 @@
+import { baseUrl } from 'config';
+import { kintoneProxyWrapper } from 'libs';
+
+export const checkServer = async () => {
+  console.log('baseUrl', baseUrl);
+  const startTime = performance.now();
+
+  try {
+    
+    const serverResponse = await kintoneProxyWrapper({
+      url: baseUrl,
+      method: 'GET',
+      headers: {},
+    });
+
+    const endTime = performance.now();
+    const runtime = endTime - startTime;
+
+
+    return {
+      runtime: runtime,
+      alive: serverResponse.status === 200,
+    };
+  } catch (e) {
+
+    const endTime = performance.now();
+
+    const runtime = endTime - startTime;
+
+    return {
+      runtime: runtime,
+      alive: false,
+    };
+  }
+};

--- a/packages/kokoas-client/src/api/others/checkServer.ts
+++ b/packages/kokoas-client/src/api/others/checkServer.ts
@@ -2,7 +2,7 @@ import { baseUrl } from 'config';
 import { kintoneProxyWrapper } from 'libs';
 
 export const checkServer = async () => {
-  console.log('baseUrl', baseUrl);
+  
   const startTime = performance.now();
 
   try {
@@ -16,13 +16,13 @@ export const checkServer = async () => {
     const endTime = performance.now();
     const runtime = endTime - startTime;
 
-
+    console.log('SeverStatus', serverResponse.status, runtime);
     return {
       runtime: runtime,
       alive: serverResponse.status === 200,
     };
   } catch (e) {
-
+    console.error(e);
     const endTime = performance.now();
 
     const runtime = endTime - startTime;

--- a/packages/kokoas-client/src/components/appBars/AppBarContent.tsx
+++ b/packages/kokoas-client/src/components/appBars/AppBarContent.tsx
@@ -1,0 +1,32 @@
+import { IconButton, Stack } from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+import { Link } from 'react-router-dom';
+import CocoLogo from './../../assets/logo-cocosumo-system.png';
+import { ServerStatus } from './serverStatus/ServerStatus';
+
+export const AppBarContent = ({
+  handleDrawerOpen,
+}:{
+  handleDrawerOpen?: () => void
+}) => {
+  return (
+    <Stack
+      direction="row"
+      spacing={2}
+    >
+      <IconButton
+        color="inherit"
+        aria-label="open drawer"
+        onClick={handleDrawerOpen}
+        edge="start"
+        sx={{ mx: 2 }}
+      >
+        <MenuIcon />
+      </IconButton>
+      <Link to="/"> 
+        <img height="40px" src={CocoLogo} alt="" />
+      </Link>
+      <ServerStatus />
+    </Stack>
+  );
+};

--- a/packages/kokoas-client/src/components/appBars/PersistentAppBar.tsx
+++ b/packages/kokoas-client/src/components/appBars/PersistentAppBar.tsx
@@ -1,12 +1,9 @@
 /* eslint-disable import/named */
-// import Toolbar from '@mui/material/Toolbar';
-import IconButton from '@mui/material/IconButton';
-import MenuIcon from '@mui/icons-material/Menu';
-import CocoLogo from './../../assets/logo-cocosumo-system.png';
+
 import { styled, useTheme } from '@mui/material/styles';
 import MuiAppBar, { AppBarProps as MuiAppBarProps } from '@mui/material/AppBar';
 import { Stack, Typography, useMediaQuery } from '@mui/material';
-import { Link } from 'react-router-dom';
+import { AppBarContent } from './AppBarContent';
 
 
 
@@ -37,35 +34,18 @@ export default function PersistentAppBar({ handleDrawerOpen }: AppBarProps) {
         direction="row"
         spacing={2}
         justifyContent="space-between"
+        alignItems={'center'}
         m={1}
       >
-        <Stack
-          direction="row"
-          spacing={2}
-        >
-          <IconButton
-            color="inherit"
-            aria-label="open drawer"
-            onClick={handleDrawerOpen}
-            edge="start"
-            sx={{ mx: 2 }}
-          >
-            <MenuIcon />
-          </IconButton>
-          <Link to="/"> 
-            {' '}
-            <img height="40px" src={CocoLogo} alt="" />
-          </Link>
-
-        </Stack>
+        <AppBarContent 
+          handleDrawerOpen={handleDrawerOpen}
+        />
         {!isSmallScreen &&
-        <div>
-          {/* <SearchField /> */}
+          (
           <Typography>
             {kintone.getLoginUser().name}
           </Typography>
-
-        </div> }
+          )}
 
 
       </Stack>

--- a/packages/kokoas-client/src/components/appBars/serverStatus/ServerStatus.tsx
+++ b/packages/kokoas-client/src/components/appBars/serverStatus/ServerStatus.tsx
@@ -1,0 +1,114 @@
+import { Alert, Box, Stack, Tooltip, Typography } from '@mui/material';
+import { useCheckServer } from 'kokoas-client/src/hooksQuery';
+import styled from '@emotion/styled';
+import { useState } from 'react';
+
+// Glowing CircleIcon
+
+const GlowingCircleIcon = styled(Box)(({ borderColor }) => ({
+  width: 25,
+  height: 25,
+  fontSize: 6,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  cursor: 'help',
+  color: 'white',
+  borderRadius: '50%',
+  whiteSpace: 'nowrap',
+  transition: 'all 0.3s ease',
+  boxShadow: `0 0 4px 4px ${borderColor}`,
+  // pulse
+  animation: 'pulse 2s infinite',
+}));
+
+const TooltipTitle = ({
+  alive,
+  runtime,
+  isFetchedAfterMount,
+}:{
+  alive: boolean;
+  runtime: number;
+  isFetchedAfterMount: boolean;
+}) => {
+
+  let status = '';
+  if (isFetchedAfterMount) {
+    if (alive) {
+      status = '正常';
+    }
+  } else {
+    status = '接続中';
+  }
+
+  if (isFetchedAfterMount && !alive) {
+    return (
+      <Alert severity="error" variant='standard' >
+        処理サーバーに接続できません。
+        <br />
+        管理者にお知らせください
+      </Alert>
+    );
+  }
+
+  return (
+    <Stack>
+      <Typography fontWeight={'bold'} fontSize={14}>
+        サーバー状態
+      </Typography>
+      <div>
+        {`ステータス：${status}`}
+      </div>
+      <div>
+        {`応答時間：${ alive ? `${Math.round(runtime)}ms` : '-' }`}
+      </div>
+    </Stack>
+  );
+};
+
+export const ServerStatus = () => {
+  const { data, isFetchedAfterMount } = useCheckServer();
+  const [open, setOpen] = useState(false);
+
+  const {
+    alive,
+    runtime,
+  } = data;
+
+  let borderColor = 'grey';
+
+  if (isFetchedAfterMount) {
+    if (alive) {
+      if (runtime < 200) {
+        borderColor = 'green';
+      } else {
+        borderColor = 'orange';
+      }
+    } else {
+      borderColor = 'red';
+    }
+  } 
+
+  return (
+    <Tooltip
+      open={isFetchedAfterMount && !alive ? true : open}
+      placement='right' 
+      arrow
+      title={<TooltipTitle {...data} isFetchedAfterMount={isFetchedAfterMount} />}
+    >
+      <Stack
+        direction="row"
+        alignItems={'center'}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+      >
+        <GlowingCircleIcon 
+          borderColor={borderColor}
+        >
+          {isFetchedAfterMount ? `${Math.round(runtime)}ms` : '接続中'}
+        </GlowingCircleIcon>
+      
+      </Stack>
+    </Tooltip>
+  );
+};

--- a/packages/kokoas-client/src/hooksQuery/index.ts
+++ b/packages/kokoas-client/src/hooksQuery/index.ts
@@ -13,6 +13,7 @@ export * from './useAndpadBySystemId';
 export * from './useAndpadCostMgtDataByProjId';
 export * from './useAndpadOrderByProjId';
 export * from './useAndpadPaymentsBySystemId';
+export * from './useCheckServer';
 export * from './useCocoAG';
 export * from './useCommonOptions';
 export * from './useCompletedTickets';

--- a/packages/kokoas-client/src/hooksQuery/useCheckServer.ts
+++ b/packages/kokoas-client/src/hooksQuery/useCheckServer.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { checkServer } from '../api/others/checkServer';
+
+export const useCheckServer = () => {
+  return useQuery({
+    queryKey: ['checkServer'],
+    queryFn: checkServer,
+    refetchInterval: 60 * 1000,
+  });
+};

--- a/packages/kokoas-client/src/hooksQuery/useCheckServer.ts
+++ b/packages/kokoas-client/src/hooksQuery/useCheckServer.ts
@@ -5,6 +5,10 @@ export const useCheckServer = () => {
   return useQuery({
     queryKey: ['checkServer'],
     queryFn: checkServer,
-    refetchInterval: 60 * 1000,
+    refetchInterval: 3000,
+    initialData: {
+      runtime: 0,
+      alive: false,
+    },
   });
 };

--- a/packages/libs/src/kitoneProxyWrapper.ts
+++ b/packages/libs/src/kitoneProxyWrapper.ts
@@ -29,10 +29,20 @@ export const kintoneProxyWrapper = async <D = unknown, S = unknown>(params: {
 
     if (status !== 200) throw new Error(body);
 
-    return {
-      data: JSON.parse(body) as D,
-      status: status as S,
-    };
+    try {
+      return {
+        data: JSON.parse(body) as D,
+        status: status as S,
+      };
+  
+    } catch (e) {
+      // Handle non-JSON response
+      return {
+        data: body as D,
+        status: status as S,
+      };
+    }
+  
   } else {
     const result = await axios({
       url,


### PR DESCRIPTION
## 変更
 
1. ![image](https://github.com/cocosumo/yumecoco-monorepo/assets/2501255/b73365f4-7086-46e0-b573-84cb0a618a2f)

## 理由

1. サーバが動いていないときに、ユーザが分かるように。
2. 

## テスト

- 実行方法
