### PR TITLE
1143-見積もりで保存後、同じところにフォーカスするように

### DIFF
--- a/packages/kokoas-client/src/pages/projEstimate/hooks/useSaveForm.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/useSaveForm.tsx
@@ -17,10 +17,13 @@ import { ja } from './utils/fieldTranslations';
 import { TForm } from '../schema';
 import { useLocalStorage } from 'usehooks-ts';
 import { localStorageFormRecoveryKey } from '../sections/UnsavedMitsumori';
+import { refocus } from './utils/refocus';
 
 export type SaveButtonNames = 'temporary' | 'save';
 
 export type UseSaveForm = ReturnType<typeof useSaveForm>;
+
+
 
 export const useSaveForm = ({
   handleSubmit,
@@ -59,43 +62,20 @@ export const useSaveForm = ({
         projDataId: data.projDataId,
       },
     });
+
     setSnackState({
       open: true,
       severity: 'success',
       message: `保存しました。 更新回数：${revision}`,
-
+      autoHideDuration: 500,
       handleClose: () => {
-        // return focus to the element that was focused before
-        const returnFocusEl = document.getElementById('activeElement');
-        returnFocusEl?.focus();
-
-        if (returnFocusEl) {
-          returnFocusEl.removeAttribute('id');
-        } else {
-          // If it is grid cell, focus on the cell
-          const parentCell = activeEl.closest('div[role="gridcell"]');
-          const parentRow = parentCell?.closest('div[role="row"]');
-          // get aria-rowindex
-          const rowIndex = parentRow?.getAttribute('aria-rowindex');
-
-          // get aria-colindex
-          const colIndex = parentCell?.getAttribute('aria-colindex');
-
-          // select the cell
-          const cellEl = document.querySelector(`div[role="grid"] div[aria-rowindex="${rowIndex}"] div[aria-colindex="${colIndex}"]`) as HTMLElement;
-
-          if (cellEl) {
-            cellEl.focus();
-          }
-
-          console.log(cellEl);
-        }
-        
+        refocus(activeEl, 'activeElement');
       },
+      
     });
 
-    
     setFormRecovery(undefined);
+
     return {
       id,
       revision,

--- a/packages/kokoas-client/src/pages/projEstimate/hooks/utils/refocus.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/utils/refocus.ts
@@ -1,0 +1,26 @@
+export const refocus = (activeEl: HTMLElement, id: string) => {
+  
+  const returnFocusEl = document.getElementById(id);
+  returnFocusEl?.focus();
+
+  if (returnFocusEl) {
+    returnFocusEl.removeAttribute('id');
+  } else {
+    // If it is grid cell, focus on the cell
+    const parentCell = activeEl.closest('div[role="gridcell"]');
+    const parentRow = parentCell?.closest('div[role="row"]');
+    // get aria-rowindex
+    const rowIndex = parentRow?.getAttribute('aria-rowindex');
+
+    // get aria-colindex
+    const colIndex = parentCell?.getAttribute('aria-colindex');
+
+    // select the cell
+    const cellEl = document.querySelector(`div[role="grid"] div[aria-rowindex="${rowIndex}"] div[aria-colindex="${colIndex}"]`) as HTMLElement;
+
+    if (cellEl) {
+      cellEl.focus();
+    }
+
+  }
+};


### PR DESCRIPTION
## 変更

1. 件名通り

## 理由

1. フォーカスを戻すのは遅かったため。

## テスト

- 見積もりを保存して、同じフィールドにフォーカスしていれるとOK。
