### PR TITLE
1176 bug 本番環境の見積入力で保存するとフォーカスが外れます

### DIFF
--- a/packages/kokoas-client/src/hooksQuery/useEstimateById.ts
+++ b/packages/kokoas-client/src/hooksQuery/useEstimateById.ts
@@ -11,7 +11,7 @@ import { AppIds } from 'config';
 export const useEstimateById = (projEstimateId: string ) => {
 
   return useQuery({
-    queryKey: ['estimate', AppIds.projEstimates, projEstimateId],
+    queryKey: [AppIds.projEstimates, projEstimateId],
     queryFn: async () => {
       const record = await getEstimateById(projEstimateId);
       return {

--- a/packages/kokoas-client/src/hooksQuery/useEstimateById.ts
+++ b/packages/kokoas-client/src/hooksQuery/useEstimateById.ts
@@ -1,26 +1,24 @@
 
-import { useEstimates } from './useEstimates';
-import { useCallback } from 'react';
-import { calculateEstimateRecord } from 'api-kintone';
+
+import { calculateEstimateRecord, getEstimateById } from 'api-kintone';
+import { useQuery } from '@tanstack/react-query';
+import { AppIds } from 'config';
 
 
 /**
  * 見積番号で取得する
  */
 export const useEstimateById = (projEstimateId: string ) => {
-  return useEstimates(({
-    enabled: !!projEstimateId,
-    select: useCallback((data) => {
-      const foundData = data.find(({ uuid }) => uuid.value === projEstimateId);
-      if (foundData) {
-        return {
-          record: foundData,
-          calculated: calculateEstimateRecord({ record: foundData }),
-        };
-      }
-    }, [
-      projEstimateId,
-    ]),
-  }));
+
+  return useQuery({
+    queryKey: ['estimate', AppIds.projEstimates, projEstimateId],
+    queryFn: async () => {
+      const record = await getEstimateById(projEstimateId);
+      return {
+        record,
+        calculated: calculateEstimateRecord({ record }),
+      };
+    },
+  });
 
 };


### PR DESCRIPTION
## 変更

1. 見積レコードの取得は、全レコードを一括取得から、単体取得に変更しました。

## 理由

1. closes #1176 

## テスト

本番で、テスト用の見積を開き、テーブルを編集し、保存して、10秒ぐらい待って、フォーカスが戻ったら、OK。
