### PR TITLE
1186-fix-工事を新規に作るとき住所の横にローディングが表示されます

### DIFF
--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/projectLocation/AddressCheck.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/projectLocation/AddressCheck.tsx
@@ -31,15 +31,15 @@ export const AddressCheck = () => {
   const combinedAddress = `${address1}${address2}`;
   const debouncedAddress = useDebounceValue(combinedAddress, 1000);
 
-  const { data: postalId, isLoading } = usePostalByAddress(combinedAddress);
+  const { data: postalId, isFetching } = usePostalByAddress(combinedAddress);
 
-  const shouldShow = !!debouncedAddress && !isLoading;
+  const shouldShow = !!debouncedAddress && !isFetching && !!address1;
 
   return (
     <Box
       position={'relative'}
     >
-      {isLoading &&  <CircularProgress />}
+      {isFetching &&  <CircularProgress size={24} />}
     
       <Zoom in={shouldShow && !!postalId}>
         <CustomAlert


### PR DESCRIPTION
## 変更

1. 件名通り

## 理由

1. fix #1186

##  テスト

- 工事登録画面で、住所が空だと、ローディングが表示されないこと。