### PR TITLE
請求書未発行アラートのボタンに権限を設定する

### DIFF
--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/UnisssuedInvoiceAlert.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/UnisssuedInvoiceAlert.tsx
@@ -1,6 +1,8 @@
 import { Stack } from '@mui/material';
 import { AlertButton } from './AlertButton';
 import { isProd } from 'config';
+import { getAlertIssuer } from './getAlertIssuer';
+import { useEmployees } from 'kokoas-client/src/hooksQuery';
 
 
 
@@ -9,19 +11,13 @@ export const UnisssuedInvoiceAlert = ({
 }: {
   projId: string
 }) => {
+  const { data: employees } = useEmployees();
 
-  if (isProd) return;
+  if (isProd) return; // 開発中設定、機能実装時に削除すること
 
-  // アラート発行の担当者かどうかを確認する
-  const getAlertIssuer = () => {
-    // 経理担当者もしくはシステム担当者
-
-    return false;
-  };
-
-  const isAlertIssuer = getAlertIssuer();
-
-  if (isAlertIssuer) return;
+  // アラート発行権限の確認
+  const isAlertIssuer = getAlertIssuer(employees);
+  if (!isAlertIssuer) return;
 
   return (
     <Stack

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/UnisssuedInvoiceAlert.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/UnisssuedInvoiceAlert.tsx
@@ -6,10 +6,22 @@ import { isProd } from 'config';
 
 export const UnisssuedInvoiceAlert = ({
   projId,
-}:{
+}: {
   projId: string
 }) => {
+
   if (isProd) return;
+
+  // アラート発行の担当者かどうかを確認する
+  const getAlertIssuer = () => {
+    // 経理担当者もしくはシステム担当者
+
+    return false;
+  };
+
+  const isAlertIssuer = getAlertIssuer();
+
+  if (isAlertIssuer) return;
 
   return (
     <Stack

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/UnisssuedInvoiceAlert.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/UnisssuedInvoiceAlert.tsx
@@ -1,8 +1,7 @@
 import { Stack } from '@mui/material';
 import { AlertButton } from './AlertButton';
 import { isProd } from 'config';
-import { getAlertIssuer } from './getAlertIssuer';
-import { useEmployees } from 'kokoas-client/src/hooksQuery';
+import { useAlertIssuer } from './hooks/useAlertIssuer';
 
 
 
@@ -11,12 +10,10 @@ export const UnisssuedInvoiceAlert = ({
 }: {
   projId: string
 }) => {
-  const { data: employees } = useEmployees();
+  // アラート発行権限の確認
+  const isAlertIssuer = useAlertIssuer();
 
   if (isProd) return; // 開発中設定、機能実装時に削除すること
-
-  // アラート発行権限の確認
-  const isAlertIssuer = getAlertIssuer(employees);
   if (!isAlertIssuer) return;
 
   return (

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/alertConfig.ts
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/alertConfig.ts
@@ -1,4 +1,6 @@
 
+export const alertIssuer = ['経理', 'システム'];
+
 export const alertPurposes = {
   'unissued': '請求書未発行(入金あり)',
   'subsidy': '補助金の請求書発行',

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/getAlertIssuer.ts
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/getAlertIssuer.ts
@@ -1,0 +1,20 @@
+import { IEmployees } from 'types';
+import { alertIssuer } from './alertConfig';
+
+
+
+/** アラート発行の担当者かどうかを確認する */
+export const getAlertIssuer = (employees: IEmployees[] | undefined) => {
+
+  if (!employees) return false;
+
+  const loginUserId = kintone.getLoginUser().employeeNumber;
+  const isCocoEmp = employees.find(({ $id }) => $id.value === loginUserId);
+
+  if (!isCocoEmp) return false;
+
+  // 経理担当者もしくはシステム担当者
+  if (alertIssuer.includes(isCocoEmp.職種.value)) return true;
+
+  return false;
+};

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/hooks/useAlertIssuer.ts
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/hooks/useAlertIssuer.ts
@@ -1,10 +1,11 @@
-import { IEmployees } from 'types';
-import { alertIssuer } from './alertConfig';
+import { alertIssuer } from '../alertConfig';
+import { useEmployees } from 'kokoas-client/src/hooksQuery';
 
 
 
 /** アラート発行の担当者かどうかを確認する */
-export const getAlertIssuer = (employees: IEmployees[] | undefined) => {
+export const useAlertIssuer = () => {
+  const { data: employees } = useEmployees();
 
   if (!employees) return false;
 


### PR DESCRIPTION
## 変更

1. アラート発行できる担当者のみにボタンを表示する

## 理由

1. closes #1193 
