### PR TITLE
feat-発注メニュとタブを本番では表示しない

### DIFF
--- a/packages/kokoas-client/src/components/nav/MainMenu.tsx
+++ b/packages/kokoas-client/src/components/nav/MainMenu.tsx
@@ -11,6 +11,7 @@ import CustomerMenu from './menus/CustomerMenu';
 import ContractMenu from './menus/ContractMenu';
 import { ConstructionMenu } from './menus/ConstructionMenu';
 import OrderMenu from './menus/OrderMenu';
+import { isProd } from 'config';
 
 export default function MainMenu() {
   return (
@@ -18,7 +19,7 @@ export default function MainMenu() {
       <CustomerMenu />
       <ConstructionMenu />
       <ContractMenu />
-      <OrderMenu />
+      {!isProd && <OrderMenu />}
 
       <Divider />
       <SystemMenu />

--- a/packages/kokoas-client/src/components/nav/MainMenu.tsx
+++ b/packages/kokoas-client/src/components/nav/MainMenu.tsx
@@ -11,7 +11,7 @@ import CustomerMenu from './menus/CustomerMenu';
 import ContractMenu from './menus/ContractMenu';
 import { ConstructionMenu } from './menus/ConstructionMenu';
 import OrderMenu from './menus/OrderMenu';
-import { isProd } from 'config';
+import { isShowDev } from 'kokoas-client/src/config/settings';
 
 export default function MainMenu() {
   return (
@@ -19,7 +19,7 @@ export default function MainMenu() {
       <CustomerMenu />
       <ConstructionMenu />
       <ContractMenu />
-      {!isProd && <OrderMenu />}
+      {isShowDev && <OrderMenu />}
 
       <Divider />
       <SystemMenu />

--- a/packages/kokoas-client/src/config/settings.ts
+++ b/packages/kokoas-client/src/config/settings.ts
@@ -5,6 +5,10 @@ import { ApiNodes } from 'types';
   
 export const baseUrl = isProd ? process.env.BASE_URL : process.env.LOCAL_URL;
 
+export const isStaging = kintone.app.getId() === 177;
+
+export const isShowDev = !isProd || isStaging;
+
 const kokoasApiRoot : ApiNodes = 'kokoas';
 
 export const kokoasAPIBaseUrl = `${baseUrl}/${kokoasApiRoot}`; 

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/DetailsDialog.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/DetailsDialog.tsx
@@ -8,6 +8,7 @@ import { DetailsContent } from './DetailsContent';
 import { SyntheticEvent, useState } from 'react';
 import { DialogCloseButton } from 'kokoas-client/src/components';
 import { DetailsDialogTitle } from './DetailsDialogTitle';
+import { isProd } from 'config';
 
 const tabs = [
   '顧客',
@@ -20,6 +21,8 @@ const tabs = [
 ] as const;
 
 export type DetailsTabs = typeof tabs[number];
+
+const prodTabs = tabs.filter((tab) => tab !== '発注'); 
 
 export const DetailsDialog = ({
   open,
@@ -62,13 +65,14 @@ export const DetailsDialog = ({
         />
         <Tabs value={tabValue} onChange={handleChange}>
           {
-            tabs.map((tab) => (
-              <Tab 
-                key={tab} 
-                label={tab}
-                value={tab}
-              />
-            ))
+            (isProd ? prodTabs : tabs)
+              .map((tab) => (
+                <Tab 
+                  key={tab} 
+                  label={tab}
+                  value={tab}
+                />
+              ))
           }
         </Tabs>
         <DialogCloseButton handleClose={handleClose} />

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/DetailsDialog.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/DetailsDialog.tsx
@@ -8,7 +8,7 @@ import { DetailsContent } from './DetailsContent';
 import { SyntheticEvent, useState } from 'react';
 import { DialogCloseButton } from 'kokoas-client/src/components';
 import { DetailsDialogTitle } from './DetailsDialogTitle';
-import { isProd } from 'config';
+import { isShowDev } from 'kokoas-client/src/config/settings';
 
 const tabs = [
   '顧客',
@@ -65,7 +65,7 @@ export const DetailsDialog = ({
         />
         <Tabs value={tabValue} onChange={handleChange}>
           {
-            (isProd ? prodTabs : tabs)
+            (isShowDev ?  tabs : prodTabs)
               .map((tab) => (
                 <Tab 
                   key={tab} 


### PR DESCRIPTION
## 変更

1. 件名通り

## 理由

1. 林さんによる、公にはなっていないため。

## 備考

ユーザには見せないが、アジャイル開発メンバー間の透明性を保ちます。
https://www.servantworks.co.jp/posts/fight-transparency/