### PR TITLE
1209-アラートの重複設定の修正

### DIFF
--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/AlertDialog.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/AlertDialog.tsx
@@ -62,7 +62,7 @@ export const AlertDialog = ({
   const isDuplication = Boolean(recUnissuedInvReminders &&
     (recUnissuedInvReminders.some(({ alertType }) => alertPurposes[purpose] === alertType.value)));
 
-  const duplicateExplanation = isDuplication ? '同アラートが既に設定されています' : '';
+  const duplicateExplanation = isDuplication ? '注:同アラートが設定されています' : '';
 
   return (
     <Dialog
@@ -102,7 +102,6 @@ export const AlertDialog = ({
           <NotificationButton
             explanation={duplicateExplanation}
             handleAlert={handleAlert}
-            isDuplication={isDuplication}
           />
         </>}
         {isLoading && <Typography>

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/NotificationButton.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/NotificationButton.tsx
@@ -4,11 +4,9 @@ import { Button, Tooltip } from '@mui/material';
 
 export const NotificationButton = ({
   explanation,
-  isDuplication,
   handleAlert,
 }: {
   explanation: string
-  isDuplication: boolean
   handleAlert: () => void
 }) => (
   <Tooltip
@@ -17,7 +15,6 @@ export const NotificationButton = ({
   >
     <span>
       <Button
-        disabled={isDuplication}
         onClick={handleAlert}
         autoFocus
       >


### PR DESCRIPTION
## 変更

1. アラートを重複して通知できるよう設定変更します

## 理由

1. closes #1209 

## テスト

- アラート通知画面にて確認、通知済みアラートでも通知ボタンが有効化されていること
