### PR TITLE
1229 hotfix 工事画面 「未定」は設定できない

### DIFF
--- a/packages/kokoas-client/src/pages/projRegisterV2/api/convertCustGroupAgentsToForm.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/api/convertCustGroupAgentsToForm.ts
@@ -34,7 +34,8 @@ export const convertCustGroupAgentsToForm = ({
   // 二つまで選択出来る。加減はこちららで行う。
   // よく変わるものなら、マスター設定に実装し、そこから取得する。
   const maxNumOfAgents = 2;
-  while (result.length < maxNumOfAgents) {
+
+  if (result.length < maxNumOfAgents) {
     result.push(getDefaultEmployee(agType));
   }
 

--- a/packages/kokoas-client/src/pages/projRegisterV2/api/fieldMapJa.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/api/fieldMapJa.ts
@@ -52,6 +52,6 @@ export const fieldMapJa: Partial<Record<KForm, string>> = {
   commRateByRole: '役職による紹介料率',
   profitRate: '利益率',
   cocoConst: 'ここすも担当者',
-  
-  isNotCocoConstConfirmed: 'ここすも担当者',
+  cocoAG: '営業担当者',
+  yumeAG: 'ゆめてつAG',
 };

--- a/packages/kokoas-client/src/pages/projRegisterV2/api/fieldMapJa.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/api/fieldMapJa.ts
@@ -51,5 +51,7 @@ export const fieldMapJa: Partial<Record<KForm, string>> = {
   commissionRate: '紹介料率',
   commRateByRole: '役職による紹介料率',
   profitRate: '利益率',
-
+  cocoConst: 'ここすも担当者',
+  
+  isNotCocoConstConfirmed: 'ここすも担当者',
 };

--- a/packages/kokoas-client/src/pages/projRegisterV2/hooks/useUpdateCommRate.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/hooks/useUpdateCommRate.ts
@@ -83,7 +83,7 @@ export const useUpdateCommRate = () => {
       newCommRate = Number(matchedRole.value.commRateByRole.value);
     } else {
       console.log('yumeCommFeeRate', yumeCommFeeRate);
-      newCommRate = Number(yumeCommFeeRate?.value);
+      newCommRate = Number(yumeCommFeeRate?.value || 0);
     }
 
     console.log('success', selectedYumeAG, newCommRate);

--- a/packages/kokoas-client/src/pages/projRegisterV2/hooks/useUpdateCommRate.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/hooks/useUpdateCommRate.ts
@@ -33,7 +33,6 @@ export const useUpdateCommRate = () => {
       value: TForm['yumeAG'][number]
     },
   }) => {
-    console.log('starting to calculate');
     
     // Deep copy, as we don't want to mutate the original value
     let selectedYumeAG: TForm['yumeAG'] = JSON.parse(JSON.stringify(getValues('yumeAG')));
@@ -49,7 +48,6 @@ export const useUpdateCommRate = () => {
     if (selectedYumeAG.some(({ empName }) => empName === 'ここすも')
     || selectedYumeAG.every(({ empId }) => !empId)) {
     // ここすも又は空の場合は、紹介料率を0にする
-      console.log('ここすも又は空の場合は、紹介料率を0にする');
       setValue('commissionRate', 0, {
         shouldValidate: true,
         shouldDirty: true,
@@ -73,20 +71,13 @@ export const useUpdateCommRate = () => {
 
     let newCommRate = 0;
 
-
-
     if (matchedEmp) {
-      console.log('matchedEmp', matchedEmp);
       newCommRate = Number(matchedEmp.value.commRateByEmp.value);
     } else if (matchedRole) {
-      console.log('matchedRole', matchedRole);
       newCommRate = Number(matchedRole.value.commRateByRole.value);
     } else {
-      console.log('yumeCommFeeRate', yumeCommFeeRate);
       newCommRate = Number(yumeCommFeeRate?.value || 0);
     }
-
-    console.log('success', selectedYumeAG, newCommRate);
 
 
     setValue('commissionRate', 

--- a/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
@@ -214,6 +214,8 @@ export const schema = z.object({
 
     // K240 工事担当者を必須。決まってない場合にも工事登録できるように、「未定」というチェックができるようにしてほしい
     const hasSelectedCocoConst = cocoConst.some((ag) => ag.empId !== '');
+
+    console.log('isNotCocoConstConfirmed', isNotCocoConstConfirmed, hasSelectedCocoConst, cocoConst);
     if (!isNotCocoConstConfirmed && !hasSelectedCocoConst) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
@@ -215,7 +215,6 @@ export const schema = z.object({
     // K240 工事担当者を必須。決まってない場合にも工事登録できるように、「未定」というチェックができるようにしてほしい
     const hasSelectedCocoConst = cocoConst.some((ag) => ag.empId !== '');
 
-    console.log('isNotCocoConstConfirmed', isNotCocoConstConfirmed, hasSelectedCocoConst, cocoConst);
     if (!isNotCocoConstConfirmed && !hasSelectedCocoConst) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
@@ -239,4 +239,5 @@ export const schema = z.object({
 
 
 export type TForm = z.infer<typeof schema>;
+export type TAgent = z.infer<typeof agentSchema>;
 export type KForm = keyof TForm;

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/formActions/FormActions.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/formActions/FormActions.tsx
@@ -35,20 +35,25 @@ export const FormActions = () => {
       })}`);
     },
     (errors) => {
-      console.warn(errors); // 保存できない原因で、残す
+      console.warn('ERRORS', errors); // 保存できない原因で、残す
       // summarize errors into string
       const errorString = Object.entries(errors).reduce((acc, [key, value]) => {
         let newAcc = acc;
-        if (value) {
+        if (Array.isArray(value)) {
+          newAcc += `${fieldMapJa[key as KForm]}：\n`;
+          value.forEach((v) => {
+            newAcc += `${v.message}\n`;
+          });
+        } else if (value) {
           const keyJa = fieldMapJa[key as KForm];
           newAcc += `${ keyJa ? `${fieldMapJa[key as KForm]}：` : ''} ${value.message}\n`;
-        }
+        } 
         return newAcc;
       }, '');
 
       setSnackState({
         open: true,
-        message: `「${errorString}」 。 不具合があれば、お手数ですが、管理者に連絡してください。`, 
+        message: `${errorString ? errorString : 'エラーが発生しました'} 。 不具合があれば、お手数ですが、管理者に連絡してください。`, 
         severity: 'error',
         
       });

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/ControlledEmpSelectField.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/ControlledEmpSelectField.tsx
@@ -11,18 +11,14 @@ export const ControlledEmpSelectField = ({
   index,
   label,
   agentType,
-  fields,
   required,
-  appendNew,
 }:{
   name: KForm,
   index: number,
   label: string,
   agentType: TAgents,
   fields: TForm['yumeAG'],
-  required?: boolean,
-  appendNew: () => void,
-}) => {
+  required?: boolean }) => {
 
   const {
     control,
@@ -31,7 +27,6 @@ export const ControlledEmpSelectField = ({
   const {
     handleUpdateCommRate,
   } = useUpdateCommRate();
-
 
   return (
     <Controller
@@ -75,12 +70,6 @@ export const ControlledEmpSelectField = ({
               };
 
               onChange(newAgent);
-
-              if (index === 0) {
-                if (selectedEmpId && fields.length === 1) {
-                  appendNew();
-                }
-              }
 
               if (agentType === 'yumeAG') {
                 handleUpdateCommRate({

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/ControlledEmpSelectField.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/ControlledEmpSelectField.tsx
@@ -1,5 +1,5 @@
 import { Controller } from 'react-hook-form';
-import { KForm, TForm } from '../../schema';
+import { KForm } from '../../schema';
 import { EmployeeSelector } from 'kokoas-client/src/components';
 import { useTypedFormContext } from '../../hooks';
 import { TAgents } from 'types';
@@ -17,7 +17,6 @@ export const ControlledEmpSelectField = ({
   index: number,
   label: string,
   agentType: TAgents,
-  fields: TForm['yumeAG'],
   required?: boolean }) => {
 
   const {
@@ -70,7 +69,6 @@ export const ControlledEmpSelectField = ({
               };
 
               onChange(newAgent);
-
               if (agentType === 'yumeAG') {
                 handleUpdateCommRate({
                   newYumeAG: {

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/EmployeeSelectFields.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/EmployeeSelectFields.tsx
@@ -2,11 +2,9 @@ import { KForm, TForm } from '../../schema';
 import { Stack } from '@mui/material';
 import { TAgents } from 'types';
 import { ControlledEmpSelectField } from './ControlledEmpSelectField';
-import { useTypedFormContext } from '../../hooks';
-import { useFieldArray } from 'react-hook-form';
-import { getDefaultEmployee } from '../../form';
+import { useTypedFormContext, useTypedWatch } from '../../hooks';
 import { useEffect } from 'react';
-import { splitFieldInternalAndForwardedProps } from '@mui/x-date-pickers/internals';
+import { getDefaultEmployee } from '../../form';
 
 
 const empFieldLabels: Partial<Record<TAgents, string>> = {
@@ -25,29 +23,27 @@ export const EmployeeSelectFields = ({
   required?: boolean,
 }) => {
 
-  const { control } = useTypedFormContext();
+  const { setValue } = useTypedFormContext();
 
-  const arrayHelpers = useFieldArray({
-    control,
+  const fieldsValues = useTypedWatch({
     name: name as 'yumeAG',
-  });
-
-  const {
-    fields,
-  } = arrayHelpers;
-
+  }) as TForm['yumeAG'];
 
   useEffect(() => {
-    console.log('fields', fields);
-  }, [fields]);
+    if (fieldsValues.length === 1 && fieldsValues[0].empId !== '') {
+      setValue(name, [...fieldsValues, getDefaultEmployee(agentType)], { shouldValidate: true });
+    } else if (fieldsValues.length === 2 && fieldsValues.every(({ empId }) => !empId )) {
+      setValue(name, [getDefaultEmployee(agentType)]);
+    }
 
+  }, [fieldsValues, setValue, name, agentType]);
 
   return (
     <Stack
       direction={'row'}
       spacing={2}
     >
-      {(fields as TForm['yumeAG'])
+      {(fieldsValues as TForm['yumeAG'])
         .map(({
           key,
         }, index) => {
@@ -59,9 +55,7 @@ export const EmployeeSelectFields = ({
               name={name}
               index={index}
               agentType={agentType}
-              fields={fields}
               required={required}
-              //appendNew={() => append(getDefaultEmployee(agentType))}
             />
           );
 

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/EmployeeSelectFields.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/EmployeeSelectFields.tsx
@@ -1,10 +1,10 @@
-import { KForm, TForm } from '../../schema';
+import { KForm } from '../../schema';
 import { Stack } from '@mui/material';
 import { TAgents } from 'types';
 import { ControlledEmpSelectField } from './ControlledEmpSelectField';
-import { useTypedFormContext, useTypedWatch } from '../../hooks';
-import { useEffect } from 'react';
-import { getDefaultEmployee } from '../../form';
+import { useTypedFormContext } from '../../hooks';
+
+import { useFieldArray } from 'react-hook-form';
 
 
 const empFieldLabels: Partial<Record<TAgents, string>> = {
@@ -23,34 +23,27 @@ export const EmployeeSelectFields = ({
   required?: boolean,
 }) => {
 
-  const { setValue } = useTypedFormContext();
+  const { control } = useTypedFormContext();
 
-  const fieldsValues = useTypedWatch({
-    name: name as 'yumeAG',
-  }) as TForm['yumeAG'];
+  const fieldHelpers = useFieldArray({
+    control,
+    name: name as 'yumeAG' | 'cocoAG' | 'cocoConst',
+  });
 
-  useEffect(() => {
-    if (fieldsValues.length === 1 && fieldsValues[0].empId !== '') {
-      setValue(name, [...fieldsValues, getDefaultEmployee(agentType)], { shouldValidate: true });
-    } else if (fieldsValues.length === 2 && fieldsValues.every(({ empId }) => !empId )) {
-      setValue(name, [getDefaultEmployee(agentType)]);
-    }
-
-  }, [fieldsValues, setValue, name, agentType]);
 
   return (
     <Stack
       direction={'row'}
       spacing={2}
     >
-      {(fieldsValues as TForm['yumeAG'])
+      {(fieldHelpers.fields )
         .map(({
-          key,
+          id,
         }, index) => {
 
           return (
             <ControlledEmpSelectField 
-              key={key}
+              key={id}
               label={`${empFieldLabels[agentType]}${index + 1}`}
               name={name}
               index={index}

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/EmployeeSelectFields.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/EmployeeSelectFields.tsx
@@ -5,6 +5,8 @@ import { ControlledEmpSelectField } from './ControlledEmpSelectField';
 import { useTypedFormContext } from '../../hooks';
 import { useFieldArray } from 'react-hook-form';
 import { getDefaultEmployee } from '../../form';
+import { useEffect } from 'react';
+import { splitFieldInternalAndForwardedProps } from '@mui/x-date-pickers/internals';
 
 
 const empFieldLabels: Partial<Record<TAgents, string>> = {
@@ -32,8 +34,12 @@ export const EmployeeSelectFields = ({
 
   const {
     fields,
-    append,
   } = arrayHelpers;
+
+
+  useEffect(() => {
+    console.log('fields', fields);
+  }, [fields]);
 
 
   return (
@@ -55,7 +61,7 @@ export const EmployeeSelectFields = ({
               agentType={agentType}
               fields={fields}
               required={required}
-              appendNew={() => append(getDefaultEmployee(agentType))}
+              //appendNew={() => append(getDefaultEmployee(agentType))}
             />
           );
 

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/IsNotCocoConstConfirmed.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/IsNotCocoConstConfirmed.tsx
@@ -4,6 +4,7 @@ import { Checkbox, FormControlLabel, Tooltip } from '@mui/material';
 
 export const IsNotCocoConstConfirmed = () => {
   const { control } = useTypedFormContext(); 
+  
   return (
     <Controller 
       name={'isNotCocoConstConfirmed'}
@@ -12,11 +13,9 @@ export const IsNotCocoConstConfirmed = () => {
         field: {
           value,
           onChange,
-          name        },
+          name },
       }) => {
-
-        console.log('value-isNotCocoConstConfirmed', value);
-
+  
         return (
           <Tooltip title={(<div>
             {'工事担当者が未定の場合は、チェックを入れてください'}

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/IsNotCocoConstConfirmed.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/IsNotCocoConstConfirmed.tsx
@@ -1,9 +1,19 @@
 import { Controller } from 'react-hook-form';
-import { useTypedFormContext } from '../../hooks';
+import { useTypedFormContext, useTypedWatch } from '../../hooks';
 import { Checkbox, FormControlLabel, Tooltip } from '@mui/material';
+import { TForm } from '../../schema';
+import { useEffect } from 'react';
 
 export const IsNotCocoConstConfirmed = () => {
-  const { control } = useTypedFormContext(); 
+  const { control, trigger } = useTypedFormContext(); 
+
+  const isNotCocoConstConfirmed = useTypedWatch({
+    name: 'isNotCocoConstConfirmed',
+  }) as TForm['isNotCocoConstConfirmed'];
+
+  useEffect(() => {
+    trigger('cocoConst.0');
+  }, [isNotCocoConstConfirmed, trigger]);
   
   return (
     <Controller 

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/IsNotCocoConstConfirmed.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/IsNotCocoConstConfirmed.tsx
@@ -1,19 +1,9 @@
 import { Controller } from 'react-hook-form';
-import { useTypedFormContext, useTypedWatch } from '../../hooks';
+import { useTypedFormContext } from '../../hooks';
 import { Checkbox, FormControlLabel, Tooltip } from '@mui/material';
-import { TForm } from '../../schema';
-import { useEffect } from 'react';
 
 export const IsNotCocoConstConfirmed = () => {
-  const { control, trigger } = useTypedFormContext(); 
-
-  const isNotCocoConstConfirmed = useTypedWatch({
-    name: 'isNotCocoConstConfirmed',
-  }) as TForm['isNotCocoConstConfirmed'];
-
-  useEffect(() => {
-    trigger('cocoConst.0');
-  }, [isNotCocoConstConfirmed, trigger]);
+  const { control } = useTypedFormContext(); 
   
   return (
     <Controller 
@@ -26,6 +16,7 @@ export const IsNotCocoConstConfirmed = () => {
           name },
       }) => {
   
+          
         return (
           <Tooltip title={(<div>
             {'工事担当者が未定の場合は、チェックを入れてください'}
@@ -40,7 +31,7 @@ export const IsNotCocoConstConfirmed = () => {
                   onChange={(_, checked) => {
                     onChange(checked);
                   }}
-                  checked={value}
+                  value={value}
                 />)} 
               label="未定"
             />

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/IsNotCocoConstConfirmed.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/IsNotCocoConstConfirmed.tsx
@@ -3,7 +3,7 @@ import { useTypedFormContext } from '../../hooks';
 import { Checkbox, FormControlLabel, Tooltip } from '@mui/material';
 
 export const IsNotCocoConstConfirmed = () => {
-  const { control, trigger } = useTypedFormContext(); 
+  const { control } = useTypedFormContext(); 
   return (
     <Controller 
       name={'isNotCocoConstConfirmed'}
@@ -12,9 +12,10 @@ export const IsNotCocoConstConfirmed = () => {
         field: {
           value,
           onChange,
-          ...otherFieldProps
-        },
+          name        },
       }) => {
+
+        console.log('value-isNotCocoConstConfirmed', value);
 
         return (
           <Tooltip title={(<div>
@@ -24,13 +25,15 @@ export const IsNotCocoConstConfirmed = () => {
           </div>)}
           >
             <FormControlLabel 
-              onChange={(_, checked) => {
-                onChange(checked);
-                trigger('cocoConst.0');
-              }}
-              control={<Checkbox checked={value} />} 
+              name={name}
+              control={(
+                <Checkbox
+                  onChange={(_, checked) => {
+                    onChange(checked);
+                  }}
+                  checked={value}
+                />)} 
               label="未定"
-              {...otherFieldProps}
             />
           </Tooltip>
 

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/projectLocation/postalField/AddressByPostal.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/projectLocation/postalField/AddressByPostal.tsx
@@ -5,9 +5,11 @@ import { getAddressByPostal } from 'api-kintone';
 import { useSnackBar } from 'kokoas-client/src/hooks';
 
 export const AddressByPostal = () => {
+  const queryClient = useQueryClient();
   const { setSnackState } = useSnackBar();
   const { getValues, setValue } = useTypedFormContext();
-  const queryClient = useQueryClient();
+  
+
 
 
   return (
@@ -17,7 +19,7 @@ export const AddressByPostal = () => {
         variant='outlined'
         onClick={() => {
           const postal = getValues('postal');
-
+          
           queryClient.fetchQuery(
             ['addressPostalCode', { postalCode: postal }],
             () => getAddressByPostal(postal as string),


### PR DESCRIPTION
## 変更

1. fieldMapJAに担当者フィールドを追加しました。
2. newCommRate　の取得を修正しました。
3. 担当者フィールドのエラ表示を修正しました。
4. useFieldArraysの appendの代わりに、 useFormのsetValuesにしました。
5. triggerをuseEffectの中に移動しました。
6. 「未定」CheckboxのonChange　から `trigger`を外しました。

## 理由

1. バリデーション通知にundefinedになるからです。
2. Numbe(undefined) = NaN からです。
3. フィールドは配列だと、エラーが出ないからです。
4. appendはレンダリング前の値を持っていて、onChangeのすぐあとにすると、[新しい値が消えます](https://react-hook-form.com/docs/usefieldarray)。
5. fix #1229
6. バリデーションでチェックされるのは、onChangeが終わる前だからです。

## テスト

当PRに各種修正を行いました。レグレッションテストをお願いします。
当変更によって発生した不具合は優先に対応します。