### PR TITLE
1234-hotfix-契約の時営業担当者が複数いる場合二人目が契約担当者になる

### DIFF
--- a/packages/api-kintone/src/employees/getEmployeesByIds.test.ts
+++ b/packages/api-kintone/src/employees/getEmployeesByIds.test.ts
@@ -1,18 +1,15 @@
 import { expect, describe, it } from '@jest/globals';
-import { RecordType } from './config';
 import { getEmployeesByIds } from './getEmployeesByIds';
 
 describe('getEmployeesByIds', () =>{
-  const existingEmpIds = ['69', '68', '70'];
-  let records: RecordType[] = [];
-
-  beforeAll(async () => {
-    const result = await getEmployeesByIds(existingEmpIds);
-    records = result.records;
-  });
+  const existingEmpIds = ['efce6ca1-48ae-4001-a9f5-0c92ad3a73c7', 'c41b4d70-8fe3-4277-99be-25d794a757f0'];
+  
   it('should get employees by existing ids', async () => {
-    const retrievedIds = records.map(({ $id }) => $id.value );
-    expect(retrievedIds.sort()).toEqual(existingEmpIds.sort());
+    const result = await getEmployeesByIds(existingEmpIds);
+    const records = result.records;
+    const resultIds = records.map(({ uuid }) => uuid.value);
+
+    expect(resultIds).toEqual(existingEmpIds);
   });
 
 });

--- a/packages/api-kintone/src/employees/getEmployeesByIds.ts
+++ b/packages/api-kintone/src/employees/getEmployeesByIds.ts
@@ -7,8 +7,19 @@ export const getEmployeesByIds = async (ids: string[]) => {
     return `${idField} = "${id}"`;
   }).join(' or ');
 
-  return getRecords<RecordType>({
+  const result = await getRecords<RecordType>({
     app: appId,
     query,
   });
+
+  const records = result.records;
+
+  const sortRecords = ids.map((id) => {
+    return records.find((record) => record.uuid.value === id) as RecordType;
+  });
+
+  return {
+    ...result,
+    records: sortRecords,
+  };
 };


### PR DESCRIPTION
## 変更

1. 件名通り

## 理由

1. fix #1234

## テスト

- getEmployeesByIds.test.ts
