### PR TITLE
原価管理表の計算処理を修正する

### DIFF
--- a/packages/api-kintone/src/andpadProcurement/calculation/calcProfitability.test.ts
+++ b/packages/api-kintone/src/andpadProcurement/calculation/calcProfitability.test.ts
@@ -12,6 +12,8 @@ describe('calcProfitability', () => {
     yumeCommFeeRate: 19,
     tax: 0.1,
     hasRefund: true,
+    subsidyAmt: 10000,
+    despositAmountSubsidy: 3000,
   };
 
   const {
@@ -33,6 +35,7 @@ describe('calcProfitability', () => {
     受注額計_税抜,
     入金額,
     未入金,
+    補助金,
   } = calcProfitability(testData);
 
 
@@ -109,5 +112,8 @@ describe('calcProfitability', () => {
     expect(未入金).toBe(0);
   });
 
+  it('正しい「補助金」を返す', () => {
+    expect(補助金).toBe(7000);
+  });
 
 });

--- a/packages/api-kintone/src/andpadProcurement/calculation/calcProfitability.ts
+++ b/packages/api-kintone/src/andpadProcurement/calculation/calcProfitability.ts
@@ -134,7 +134,8 @@ export const calcProfitability = (params: {
    * 補助金 
    * K236 補助金が入金されてたら、原価管理表には表示しない。
   */
-  const parsedSubsidyAmt = subsidyAmt > 0 ? subsidyAmt - despositAmountSubsidy : 0;
+  const parsedSubsidyAmt = subsidyAmt > 0 ? Big(subsidyAmt).minus(despositAmountSubsidy)
+    .toNumber() : 0;
 
   return {
     orderAmountBeforeTax: orderAmountBeforeTax,


### PR DESCRIPTION
## 変更

1. 原価管理表の計算処理を修正します

## 理由

1. Big.jsを使用したほうが正確性が上がるため

## テスト

- calcProfitability.test.ts ※補助金追加