### PR TITLE
1261-fix-発注登録の画面で行を削除したらフォーカスが無くなるという現象を修正しました。

### DIFF
--- a/packages/kokoas-client/src/pages/order/inputGrid/useDataGridKeyCellKeyDown.ts
+++ b/packages/kokoas-client/src/pages/order/inputGrid/useDataGridKeyCellKeyDown.ts
@@ -6,7 +6,6 @@ import { TForm } from '../schema';
 import { useRowValues } from './useRowValues';
 
 
-
 /**
  * Handles the keydown event of the DataGrid
  * ここには、Datagridのkeydownイベントを処理する関数が入っている。
@@ -155,8 +154,7 @@ export const useDataGridKeyCellKeyDown = (
       // 選択中のセルで、行を削除する。
       if (isHeadRow) return; // ヘッダーの場合、削除しない。
       remove(rowIdx);
-
-      selectCell({ rowIdx: rowIdx - 1, idx }, true);
+      selectCell({ rowIdx: rowIdx - 1, idx });
 
       preventDefault();
       return;


### PR DESCRIPTION
## 変更

1. 行削除の selectCell の オプションから、true を 外しました。

## 理由

1. 

## テスト

- 実行方法
