### PR TITLE
fix-1293-編集モードが切れる。

### DIFF
--- a/packages/kokoas-client/src/pages/order/inputGrid/renderers/CustomAutocomplete.tsx
+++ b/packages/kokoas-client/src/pages/order/inputGrid/renderers/CustomAutocomplete.tsx
@@ -37,7 +37,6 @@ export const CustomAutocomplete = ({
       options={uniqueData ?? []}
       onChange={(_, value) => {
         onRowChange({ ...row, [key]: value || '' }, true);
-        console.log('CHANGED!');
       }}
       renderInput={(params) => (
         <TextField

--- a/packages/kokoas-client/src/pages/order/inputGrid/renderers/CustomAutocomplete.tsx
+++ b/packages/kokoas-client/src/pages/order/inputGrid/renderers/CustomAutocomplete.tsx
@@ -37,9 +37,7 @@ export const CustomAutocomplete = ({
       options={uniqueData ?? []}
       onChange={(_, value) => {
         onRowChange({ ...row, [key]: value || '' }, true);
-      }}
-      onBlur={(e) => {
-        onRowChange({ ...row, [key]: (e.target as HTMLInputElement).value }, true);
+        console.log('CHANGED!');
       }}
       renderInput={(params) => (
         <TextField

--- a/packages/kokoas-client/src/pages/order/inputGrid/useChangeRows.ts
+++ b/packages/kokoas-client/src/pages/order/inputGrid/useChangeRows.ts
@@ -3,7 +3,6 @@ import { roundTo } from 'libs';
 import { KItem } from '../schema';
 import { FillEvent } from 'react-data-grid';
 import { RowItem } from './useColumns';
-import { produce } from 'immer';
 import { useTypedFormContext } from '../hooks/useTypedRHF';
 
 
@@ -48,21 +47,18 @@ export const useChangeRows = () => {
     fieldName: KItem,
     rows: RowItem[],
   ) => {
-    //update(index, newRow);
 
-    setValue(
-      'items', 
-      produce(rows, draft => {
-        indexes.forEach((index) => {
-          draft[index] = calculatedRow(draft[index], fieldName);
-        });
-      }),
-      {
-        shouldValidate: true,
-        shouldDirty: true,
-        shouldTouch: true,
-      },
-    );
+    indexes.forEach((index) => {
+      setValue(
+        `items.${index}`, 
+        calculatedRow(rows[index], fieldName),
+        {
+          shouldValidate: true,
+          shouldDirty: true,
+          shouldTouch: true,
+        },
+      );
+    });
 
   }, [ 
     setValue, 

--- a/packages/kokoas-client/src/pages/order/orderRequestForm/orderDialogContent/orderItems/useChangeRows.ts
+++ b/packages/kokoas-client/src/pages/order/orderRequestForm/orderDialogContent/orderItems/useChangeRows.ts
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
 import { roundTo } from 'libs';
 import { RowItem } from './useColumns';
-import { produce } from 'immer';
 import { KItem } from '../../../schema';
 import { useOrderFormContext } from '../../hooks/useOrderRHF';
 import { useController } from 'react-hook-form';
@@ -56,21 +55,17 @@ export const useChangeRows = () => {
     fieldName: KItem,
     rows: RowItem[],
   ) => {
-    //update(index, newRow);
 
-    setValue(
-      'selectedItems', 
-      produce(rows, draft => {
-        indexes.forEach((index) => {
-          draft[index] = calculatedRow(draft[index], fieldName);
-        });
-      }),
-      {
-        shouldValidate: true,
-        shouldDirty: true,
-        shouldTouch: true,
-      },
-    );
+    indexes.forEach((index) => {
+      setValue(
+        `selectedItems.${index}`, calculatedRow(rows[index], fieldName),
+        {
+          shouldValidate: true,
+          shouldDirty: true,
+          shouldTouch: true,
+        },
+      );
+    });
 
   }, [ 
     setValue, 

--- a/packages/kokoas-client/src/pages/projEstimate/estimateDataGrid/useChangeRows.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/estimateDataGrid/useChangeRows.ts
@@ -4,10 +4,6 @@ import { calculateRowAmount, roundTo } from 'libs';
 import { KItem, TForm } from '../schema';
 import { FillEvent } from 'react-data-grid';
 import { RowItem } from './useColumns';
-import { produce } from 'immer';
-
-
-
 
 
 export const useChangeRows = () => {
@@ -92,21 +88,18 @@ export const useChangeRows = () => {
     fieldName: KItem,
     rows: RowItem[],
   ) => {
-    //update(index, newRow);
 
-    setValue(
-      'items', 
-      produce(rows, draft => {
-        indexes.forEach((index) => {
-          draft[index] = calculatedRow(draft[index], fieldName);
-        });
-      }),
-      {
-        shouldValidate: true,
-        shouldDirty: true,
-        shouldTouch: true,
-      },
-    );
+    indexes.forEach((index) => {
+      setValue(
+        `items.${index}`, 
+        calculatedRow(rows[index], fieldName),
+        {
+          shouldValidate: true,
+          shouldDirty: true,
+          shouldTouch: true,
+        },
+      );
+    });
 
   }, [ 
     setValue, 


### PR DESCRIPTION
## 変更

- setValueの対象は全テーブルから、行ごとに変更しました。

## 理由

- 前はフィールドの値を変更したら、テーブル全体がレンダリングされるので、編集モードが切れる原因になる。

## テスト

- fix #1293 に基づく