### PR TITLE
1297 発注依頼のバリデーションが機能している

### DIFF
--- a/packages/kokoas-client/src/pages/order/orderRequestForm/orderDialogContent/OrderName.tsx
+++ b/packages/kokoas-client/src/pages/order/orderRequestForm/orderDialogContent/OrderName.tsx
@@ -23,7 +23,6 @@ export const OrderName = () => {
           fullWidth
           variant={'outlined'}
           size={'small'}
-          required
           InputProps={{
             style: { maxWidth: '400px' },
           }}

--- a/packages/kokoas-client/src/pages/order/orderRequestForm/orderDialogContent/orderMethod/EmailFields.tsx
+++ b/packages/kokoas-client/src/pages/order/orderRequestForm/orderDialogContent/orderMethod/EmailFields.tsx
@@ -11,7 +11,7 @@ export const EmailFields = () => {
 
 
   return (
-    <Fade in={orderMethod === 'email'} >
+    <Fade in={orderMethod === 'メール'} >
       <Stack
         spacing={2}
         direction={'row'}

--- a/packages/kokoas-client/src/pages/order/orderRequestForm/orderDialogContent/orderMethod/EmailToField.tsx
+++ b/packages/kokoas-client/src/pages/order/orderRequestForm/orderDialogContent/orderMethod/EmailToField.tsx
@@ -54,7 +54,7 @@ export const EmailToField = () => {
             onChange={(_, newValue) => {
               setValue('supplierOfficerId', newValue?.officerId ?? '');
               setValue('supplierOfficerName', newValue?.officerName ?? '');
-              setValue('supplierOfficerEmail', newValue?.officerTel ?? '');
+              setValue('supplierOfficerEmail', newValue?.label ?? '');
               setValue('supplierOfficerTel', newValue?.officerTel ?? '');
             }}
             renderInput={(params) => (

--- a/packages/kokoas-client/src/pages/order/orderRequestForm/orderDialogContent/orderMethod/OrderMethodChoices.tsx
+++ b/packages/kokoas-client/src/pages/order/orderRequestForm/orderDialogContent/orderMethod/OrderMethodChoices.tsx
@@ -1,12 +1,14 @@
 import { 
   FormControl, 
   FormControlLabel, 
+  FormHelperText, 
   FormLabel, 
   Radio, 
   RadioGroup, 
 } from '@mui/material';
 import { useOrderFormContext } from '../../hooks/useOrderRHF';
 import { Controller } from 'react-hook-form';
+import { orderMethodChoices } from '../../schema';
 
 export const OrderMethodChoices = () => {
   const { control } = useOrderFormContext();
@@ -15,7 +17,10 @@ export const OrderMethodChoices = () => {
     <Controller
       name={'orderMethod'}
       control={control}
-      render={({ field }) => (
+      render={({ 
+        field,
+        fieldState: { error },
+      }) => (
         <FormControl
           required
           sx={{
@@ -24,6 +29,7 @@ export const OrderMethodChoices = () => {
             alignItems: 'center',
             gap: '16px',
           }}
+          error={!!error}
         >
           <FormLabel>
             発注方法
@@ -32,9 +38,18 @@ export const OrderMethodChoices = () => {
             row
             {...field}
           >
-            <FormControlLabel value="print" control={<Radio />} label="印刷" />
-            <FormControlLabel value="email" control={<Radio />} label="メール" />
+            {orderMethodChoices.map((choice) => (
+              <FormControlLabel
+                key={choice}
+                value={choice}
+                control={<Radio />}
+                label={choice}
+              />
+            ))}
           </RadioGroup>
+          <FormHelperText>
+            {error?.message}
+          </FormHelperText>
         </FormControl>
       )}
 

--- a/packages/types/src/dtsgen/db.order.d.ts
+++ b/packages/types/src/dtsgen/db.order.d.ts
@@ -12,7 +12,7 @@ declare namespace DBOrder {
     supplierName: kintone.fieldTypes.SingleLineText;
     supplierEmail: kintone.fieldTypes.SingleLineText;
     expectedDeliveryDate: kintone.fieldTypes.SingleLineText;
-    orderMethod: kintone.fieldTypes.DropDown;
+    orderMethod: kintone.fieldTypes.SingleLineText;
     supplierOfficerId: kintone.fieldTypes.SingleLineText;
     orderDate: kintone.fieldTypes.SingleLineText;
     supplierOfficerEmail: kintone.fieldTypes.SingleLineText;

--- a/packages/types/src/dtsgen/db.orderBudget.d.ts
+++ b/packages/types/src/dtsgen/db.orderBudget.d.ts
@@ -7,17 +7,18 @@ declare namespace DBOrderbudget {
         id: string;
         value: {
           supplierName: kintone.fieldTypes.SingleLineText;
-          middleItem: kintone.fieldTypes.SingleLineText;
-          majorItem: kintone.fieldTypes.SingleLineText;
-          taxRate: kintone.fieldTypes.Number;
-          unit: kintone.fieldTypes.SingleLineText;
           quantity: kintone.fieldTypes.Number;
-          material: kintone.fieldTypes.SingleLineText;
           orderId: kintone.fieldTypes.SingleLineText;
           costPrice: kintone.fieldTypes.Number;
           rowRemarks: kintone.fieldTypes.SingleLineText;
           orderAmountBeforeTax: kintone.fieldTypes.Number;
+          middleItem: kintone.fieldTypes.SingleLineText;
+          majorItem: kintone.fieldTypes.SingleLineText;
+          taxRate: kintone.fieldTypes.Number;
+          unit: kintone.fieldTypes.SingleLineText;
+          material: kintone.fieldTypes.SingleLineText;
           orderDataId: kintone.fieldTypes.SingleLineText;
+          status: kintone.fieldTypes.SingleLineText;
         };
       }>;
     };


### PR DESCRIPTION
## 派生元

- #1245 がマージされたら、チェックをお願いします！

## 変更

- 発注一欄DBに行ごとのステータスを再追加しました。

## 理由

- 便利に取得出来るため。ただ、発注明細にかかわる保存処理は、必ず発注一覧DBも更新をかける。(汎用性は未対応)

## テスト

- closes #1297 