### PR TITLE
hotfix-入金タブを開くとエラー終了してしまう

### DIFF
--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/hooks/useActiveUnissuedInvRemindersByProjId.ts
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/unissuedInvoiceAlert/hooks/useActiveUnissuedInvRemindersByProjId.ts
@@ -8,7 +8,7 @@ export const useActiveUnissuedInvRemindersByProjId = (projId: string) => {
     ?.filter(({ 
       projId: projIdReminder,
       alertState,
-    }) => (alertState.value !== '0' && projIdReminder.value === projId));
+    }) => (alertState?.value !== '0' && projIdReminder?.value === projId));
 
   return recUnissuedInvReminders;
 };


### PR DESCRIPTION
## 変更

1. タイトルの通り

## 理由

1. 未取得のデータを参照している可能性がある

