### PR TITLE
1343 請求書画でステータスが分かる

### DIFF
--- a/packages/kokoas-client/src/hooks/useIsFormBusy.ts
+++ b/packages/kokoas-client/src/hooks/useIsFormBusy.ts
@@ -1,0 +1,32 @@
+import { useIsFetching } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useLazyEffect } from './useLazyEffect';
+
+
+/**
+ * Helps to determine if a form, and global cache is busy or not.
+ * Inspiration from waitForNetworkIdle of puppeteer. 
+ *  
+ * @param wait - The time to wait before determining if the form is busy or not.
+ */
+export const useIsFormBusy = (wait = 1000) => {
+  const [isBusy, setIsBusy] = useState(true);
+
+  const { formState: {
+    isSubmitting,
+  } } = useFormContext();
+  
+  
+  const isFetching = useIsFetching();
+  
+  useLazyEffect(() => {
+    if (isSubmitting || Boolean(isFetching)) return;
+
+    setIsBusy(false);
+  
+  }, [isSubmitting, isFetching], wait);
+
+  return isBusy; 
+};
+

--- a/packages/kokoas-client/src/hooks/useIsFormIdle.ts
+++ b/packages/kokoas-client/src/hooks/useIsFormIdle.ts
@@ -6,7 +6,7 @@ import { useLazyEffect } from './useLazyEffect';
 
 /**
  * Helps to determine if a form, and global cache is idle or not.
- * Inspiration from waitForNetworkIdle of puppeteer. 
+ * ※ Inspired by waitForNetworkIdle of puppeteer. 
  *  
  * @param wait - The time to wait before determining if the form is idle or not.
  */

--- a/packages/kokoas-client/src/hooks/useIsFormIdle.ts
+++ b/packages/kokoas-client/src/hooks/useIsFormIdle.ts
@@ -5,13 +5,13 @@ import { useLazyEffect } from './useLazyEffect';
 
 
 /**
- * Helps to determine if a form, and global cache is busy or not.
+ * Helps to determine if a form, and global cache is idle or not.
  * Inspiration from waitForNetworkIdle of puppeteer. 
  *  
- * @param wait - The time to wait before determining if the form is busy or not.
+ * @param wait - The time to wait before determining if the form is idle or not.
  */
-export const useIsFormBusy = (wait = 1000) => {
-  const [isBusy, setIsBusy] = useState(true);
+export const useIsFormIdle = (wait = 1000) => {
+  const [isIdle, setIsIdle] = useState(false);
 
   const { formState: {
     isSubmitting,
@@ -23,10 +23,10 @@ export const useIsFormBusy = (wait = 1000) => {
   useLazyEffect(() => {
     if (isSubmitting || Boolean(isFetching)) return;
 
-    setIsBusy(false);
+    setIsIdle(true);
   
   }, [isSubmitting, isFetching], wait);
 
-  return isBusy; 
+  return isIdle; 
 };
 

--- a/packages/kokoas-client/src/lib/progressColors.tsx
+++ b/packages/kokoas-client/src/lib/progressColors.tsx
@@ -1,0 +1,20 @@
+import { blue, blueGrey, green, lightGreen, orange, yellow } from '@mui/material/colors';
+import { KProgress } from 'types/src/common/order';
+
+export const statusBGcolorMap: Record<KProgress, string> = {
+  未発注: blueGrey[50],
+  発注済: blue[600],
+  請求済: orange[600],
+  請求承認済: yellow[600],
+  請求確認済: lightGreen[600],
+  支払済: green[600],
+};
+
+export const statusFGcolorMap: Record<KProgress, string> = {
+  未発注: blueGrey[600],
+  発注済: blue[50],
+  請求済: orange[50],
+  請求承認済: yellow[50],
+  請求確認済: lightGreen[50],
+  支払済: green[50],
+};

--- a/packages/kokoas-client/src/lib/progressColors.tsx
+++ b/packages/kokoas-client/src/lib/progressColors.tsx
@@ -5,8 +5,8 @@ export const statusBGcolorMap: Record<KProgress, string> = {
   未発注: blueGrey[50],
   発注済: blue[600],
   請求済: orange[600],
-  請求承認済: yellow[600],
-  請求確認済: lightGreen[600],
+  請求確認済: yellow[900],
+  請求承認済: lightGreen[900],
   支払済: green[600],
 };
 
@@ -14,7 +14,7 @@ export const statusFGcolorMap: Record<KProgress, string> = {
   未発注: blueGrey[600],
   発注済: blue[50],
   請求済: orange[50],
-  請求承認済: yellow[50],
-  請求確認済: lightGreen[50],
+  請求確認済: yellow[50],
+  請求承認済: lightGreen[50],
   支払済: green[50],
 };

--- a/packages/kokoas-client/src/pages/order/inputGrid/renderers/renderStatus.tsx
+++ b/packages/kokoas-client/src/pages/order/inputGrid/renderers/renderStatus.tsx
@@ -1,30 +1,13 @@
 import { RenderCellProps } from 'react-data-grid';
 import { Chip, styled } from '@mui/material';
 import { RowItem } from '../useColumns';
-import { KOrderProgress, KProgress } from 'types/src/common/order';
-import { blueGrey, green, lightGreen, orange, blue, yellow } from '@mui/material/colors';
+import { KOrderProgress } from 'types/src/common/order';
 import { useSetAtom } from 'jotai';
 import { invoiceDialogAtom } from '../../invoiceForm/InvoiceFormDialog';
 import { useTypedFormContext } from '../../hooks/useTypedRHF';
 import { useCallback } from 'react';
+import { statusBGcolorMap, statusFGcolorMap } from 'kokoas-client/src/lib/progressColors';
 
-const statusBGcolorMap: Record<KProgress, string> = {
-  未発注: blueGrey[50],
-  発注済: blue[600],
-  請求済: orange[600],
-  請求承認済: yellow[600],
-  請求確認済: lightGreen[600],
-  支払済: green[600],
-};
-
-const statusFGcolorMap: Record<KProgress, string> = {
-  未発注: blueGrey[600],
-  発注済: blue[50],
-  請求済: orange[50],
-  請求承認済: yellow[50],
-  請求確認済: lightGreen[50],
-  支払済: green[50],
-};
 
 const CustomChip = styled(Chip)(({ label, onClick }) => ({
   backgroundColor: statusBGcolorMap[label as KOrderProgress],

--- a/packages/kokoas-client/src/pages/order/invoiceForm/hooks/useNextStatus.ts
+++ b/packages/kokoas-client/src/pages/order/invoiceForm/hooks/useNextStatus.ts
@@ -4,12 +4,19 @@ import { getNextInvoiceStatus } from 'api-kintone/src/invoiceB2B/helpers/getNext
 
 export const useNextInvoiceStatus = () => {
   const { control } = useInvoiceFormContext();
-  const invoiceStatus = useWatch({
+  const [
+    invoiceStatus,
+  ] = useWatch({
     control,
-    name: 'invoiceStatus',
+    name: [
+      'invoiceStatus',
+    ],
   });
 
   const nextInvoiceStatus = getNextInvoiceStatus(invoiceStatus);
 
-  return nextInvoiceStatus;
+  return {
+    current: invoiceStatus,
+    next: nextInvoiceStatus,
+  };
 };

--- a/packages/kokoas-client/src/pages/order/invoiceForm/invoiceDialogActions/InvoiceDialogActions.tsx
+++ b/packages/kokoas-client/src/pages/order/invoiceForm/invoiceDialogActions/InvoiceDialogActions.tsx
@@ -1,12 +1,14 @@
-import { Button, DialogActions, Fade } from '@mui/material';
+import { Button, CircularProgress, DialogActions, Fade } from '@mui/material';
 import { useSaveInvoiceForm } from '../hooks/useSaveInvoiceForm';
 
 import { useNextInvoiceStatus } from '../hooks/useNextStatus';
 import { useInvoiceWatch } from '../hooks/useInvoiceRHF';
 import { useConfirmDialog } from 'kokoas-client/src/hooks';
+import { useIsFormBusy } from 'kokoas-client/src/hooks/useIsFormBusy';
 
 export const InvoiceDialogActions = () => {
   const { setDialogState } = useConfirmDialog();
+  const isBusy = useIsFormBusy();
   const invoiceId = useInvoiceWatch({
     name: 'invoiceId',
   }) as string;
@@ -26,25 +28,27 @@ export const InvoiceDialogActions = () => {
         height: '50px',
       }}
     >
-      {current !== '支払済' && (
-      <Button
-        color='info'   
-        variant='contained' 
-        onClick={(e) => {
-          setDialogState({
-            open: true,
-            title: `ステータスは【${next}】に更新しますか？`,
-            handleYes: () => handleSubmit(e),
-          });
-                
-              
-        }}
-      >
-        {!!invoiceId && next}
-        {invoiceId === '' && '請求確認済'}
-      </Button>
+      <Fade in={!isBusy && current === '支払済'}>
+        <Button
+          color='info'   
+          variant='contained' 
+          onClick={(e) => {
+            setDialogState({
+              open: true,
+              title: `ステータスは【${next}】に更新しますか？`,
+              handleYes: () => handleSubmit(e),
+            });
+                      
+          }}
+        >
+          {!!invoiceId && next}
+          {invoiceId === '' && '請求確認済'}
+        </Button>
+      </Fade>
+      
+      {isBusy && (
+        <CircularProgress size={16} />
       )}
-
     </DialogActions>
   );
 };

--- a/packages/kokoas-client/src/pages/order/invoiceForm/invoiceDialogActions/InvoiceDialogActions.tsx
+++ b/packages/kokoas-client/src/pages/order/invoiceForm/invoiceDialogActions/InvoiceDialogActions.tsx
@@ -1,24 +1,50 @@
-import { Button, DialogActions } from '@mui/material';
+import { Button, DialogActions, Fade } from '@mui/material';
 import { useSaveInvoiceForm } from '../hooks/useSaveInvoiceForm';
 
+import { useNextInvoiceStatus } from '../hooks/useNextStatus';
+import { useInvoiceWatch } from '../hooks/useInvoiceRHF';
+import { useConfirmDialog } from 'kokoas-client/src/hooks';
+
 export const InvoiceDialogActions = () => {
+  const { setDialogState } = useConfirmDialog();
+  const invoiceId = useInvoiceWatch({
+    name: 'invoiceId',
+  }) as string;
   const {
     handleSubmit,
   } = useSaveInvoiceForm();
+
+  const {
+    current,
+    next,
+  } = useNextInvoiceStatus();
 
   return (
     <DialogActions
       sx={{
         justifyContent: 'center',
+        height: '50px',
       }}
     >
+      {current !== '支払済' && (
       <Button
         color='info'   
         variant='contained' 
-        onClick={handleSubmit}
+        onClick={(e) => {
+          setDialogState({
+            open: true,
+            title: `ステータスは【${next}】に更新しますか？`,
+            handleYes: () => handleSubmit(e),
+          });
+                
+              
+        }}
       >
-        請求確認
+        {!!invoiceId && next}
+        {invoiceId === '' && '請求確認済'}
       </Button>
+      )}
+
     </DialogActions>
   );
 };

--- a/packages/kokoas-client/src/pages/order/invoiceForm/invoiceDialogActions/InvoiceDialogActions.tsx
+++ b/packages/kokoas-client/src/pages/order/invoiceForm/invoiceDialogActions/InvoiceDialogActions.tsx
@@ -4,11 +4,11 @@ import { useSaveInvoiceForm } from '../hooks/useSaveInvoiceForm';
 import { useNextInvoiceStatus } from '../hooks/useNextStatus';
 import { useInvoiceWatch } from '../hooks/useInvoiceRHF';
 import { useConfirmDialog } from 'kokoas-client/src/hooks';
-import { useIsFormBusy } from 'kokoas-client/src/hooks/useIsFormBusy';
+import { useIsFormIdle } from 'kokoas-client/src/hooks/useIsFormIdle';
 
 export const InvoiceDialogActions = () => {
   const { setDialogState } = useConfirmDialog();
-  const isBusy = useIsFormBusy();
+  const isFormIdle = useIsFormIdle();
   const invoiceId = useInvoiceWatch({
     name: 'invoiceId',
   }) as string;
@@ -28,7 +28,7 @@ export const InvoiceDialogActions = () => {
         height: '50px',
       }}
     >
-      <Fade in={!isBusy && current === '支払済'}>
+      <Fade in={isFormIdle && current !== '支払済'}>
         <Button
           color='info'   
           variant='contained' 
@@ -46,7 +46,7 @@ export const InvoiceDialogActions = () => {
         </Button>
       </Fade>
       
-      {isBusy && (
+      {!isFormIdle && (
         <CircularProgress size={16} />
       )}
     </DialogActions>

--- a/packages/kokoas-client/src/pages/order/invoiceForm/invoiceDialogTitle/InvoiceDialogTitle.tsx
+++ b/packages/kokoas-client/src/pages/order/invoiceForm/invoiceDialogTitle/InvoiceDialogTitle.tsx
@@ -3,6 +3,7 @@ import { SupplierName } from './SupplierName';
 import { ProjectName } from './ProjectName';
 import { useIsFetching } from '@tanstack/react-query';
 import { OrderDataId } from './OrderDataId';
+import { InvoiceStatus } from './InvoiceStatus';
 
 export const InvoiceDialogTitle = () => {
   const isFetching = useIsFetching();
@@ -19,6 +20,7 @@ export const InvoiceDialogTitle = () => {
       <SupplierName /> 
       <ProjectName />
       <OrderDataId />
+      <InvoiceStatus />
       {Boolean(isFetching) && (
         <CircularProgress size={16} />
       )}

--- a/packages/kokoas-client/src/pages/order/invoiceForm/invoiceDialogTitle/InvoiceStatus.tsx
+++ b/packages/kokoas-client/src/pages/order/invoiceForm/invoiceDialogTitle/InvoiceStatus.tsx
@@ -1,0 +1,26 @@
+import { Chip, Zoom } from '@mui/material';
+import { useInvoiceWatch } from '../hooks/useInvoiceRHF';
+import { TInvoiceForm } from '../schema';
+import { statusBGcolorMap, statusFGcolorMap } from 'kokoas-client/src/lib/progressColors';
+
+export const InvoiceStatus = () => {
+  const invoiceStatus = useInvoiceWatch({
+    name: 'invoiceStatus',
+  }) as TInvoiceForm['invoiceStatus'];
+
+  return (
+    <Zoom in={!!invoiceStatus}>
+      <Chip 
+        label={invoiceStatus}
+        size={'small'}
+        sx={invoiceStatus 
+          ? {
+            backgroundColor: statusBGcolorMap[invoiceStatus],
+            color: statusFGcolorMap[invoiceStatus],
+          }
+          : undefined}
+      />
+    </Zoom>
+  
+  );
+};

--- a/packages/kokoas-client/src/pages/order/invoiceForm/invoiceDialogTitle/InvoiceStatus.tsx
+++ b/packages/kokoas-client/src/pages/order/invoiceForm/invoiceDialogTitle/InvoiceStatus.tsx
@@ -11,6 +11,7 @@ export const InvoiceStatus = () => {
   return (
     <Zoom in={!!invoiceStatus}>
       <Chip 
+        key={invoiceStatus}
         label={invoiceStatus}
         size={'small'}
         sx={invoiceStatus 


### PR DESCRIPTION
## 変更

1. ステータスが分かるものを配置しました。
![image](https://github.com/cocosumo/yumecoco-monorepo/assets/2501255/c7ae1d02-0c08-414b-bb7e-add27a75fb84)
2. 色の設定をリファクタリングしました。
3. useIsFormIdleというhookを追加しました。

## 理由

1. 要件を満たすため
2. ステータスを表示する画面が多く、変更が予想されるため、統一化しました。これで変更は一カ所で済みます。
3. ボタンは初期のレンダリングと複数のリソースの読み込み状態の間で現れたり消えたりしたため。


## テスト

- closes #1343 