### PR TITLE
契約確認担当者の取得処理を修正します

### DIFF
--- a/packages/api-kintone/src/employees/getContractCheckers.test.ts
+++ b/packages/api-kintone/src/employees/getContractCheckers.test.ts
@@ -7,7 +7,7 @@ describe('getContractCheckers', () => {
     const {
       uuid: storeId,
       territory,
-    } = await getStoreById('83128853-98af-47af-9e5a-9d711bee4a43');
+    } = await getStoreById('df176cb7-b731-466b-a354-a1cd5cc8f748');
     const result = await getContractCheckers({
       storeId: storeId.value,
       territory: territory.value,

--- a/packages/api-kintone/src/employees/getContractCheckers.ts
+++ b/packages/api-kintone/src/employees/getContractCheckers.ts
@@ -33,23 +33,27 @@ export const getContractCheckers = async ({
   const empTerritory: KEmployees = 'territory_v2';
   const empStoreId: KEmployees = 'mainStoreId_v2';
   const cocosumo: EmpAffiliations = 'ここすも';
+  const condition: KEmployees = '状態';
 
   const storeMgrQuery = [
     `${keyStoreId} in ("${storeId}")`,
     `${affiliation} in ("${cocosumo}")`,
     `${role} in ("店長")`,
+    `${condition} in ("有効")`,
   ].join(' and ');
 
   const accountingQuery = [
     `${role} in ("経理")`,
     `${affiliation} in ("${cocosumo}")`,
     `${empTerritory} = "${territory}"`,
+    `${condition} in ("有効")`,
   ].join(' and ');
 
   const accountingHQQuery = [
     `${role} in ("経理")`,
     `${affiliation} in ("山豊")`,
     `${empStoreId} = "${hqStoreId}"`,
+    `${condition} in ("有効")`,
   ].join(' and ');
 
   // https://rdmuhwtt6gx7.cybozu.com/k/34/show#record=152
@@ -57,6 +61,7 @@ export const getContractCheckers = async ({
     `${role} in ("経理")`,
     `${affiliation} in ("${cocosumo}")`,
     `uuid = "${subAccountingId}"`,
+    `${condition} in ("有効")`,
   ].join(' and ');
 
   const finalQuery = [


### PR DESCRIPTION
## 変更

1. タイトルの通り

## 理由

1. 無効なレコードも取得してしまっていたため

## テスト

- getContractCheckers.test.tsの実行
