### PR TITLE
fix-bug-見積が新規の際に、案件の粗利率を１行目の項目の粗利に反映されない

### DIFF
--- a/packages/kokoas-client/src/pages/projEstimate/hooks/useResolveParam.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/useResolveParam.ts
@@ -79,6 +79,10 @@ export const useResolveParam = () => {
         ...prev,
         ...convertProjToForm(recProj),
         ...convertProjTypeToForm(recProjType),
+        items: prev.items.map((item) => ({
+          ...item,
+          materialProfRate: profRate,
+        })),
         projTypeProfit: profRate,
       }));
       


### PR DESCRIPTION
## 変更

- 新規の際に、案件の粗利率を見積の項目の粗利に反映させました。

## 理由

- 行の粗利率のデフォルトは案件の粗利を反映させる要件があるため。

## 関連

- #1482