### PR TITLE
1507-請求金額を手入力すると保存できなくなるバグの修正

### DIFF
--- a/packages/kokoas-client/src/pages/projInvoiceV2/sections/InputInvoice/InputSection/BillingAmount.tsx
+++ b/packages/kokoas-client/src/pages/projInvoiceV2/sections/InputInvoice/InputSection/BillingAmount.tsx
@@ -40,7 +40,7 @@ export const BillingAmount = ({
             error={!!error}
             helperText={error?.message}
             onChange={(e) => {
-              onChange(e.target.value);
+              onChange(+e.target.value);
               handleChange(+e.target.value, index);
             }}
             required={required}


### PR DESCRIPTION
## 変更

1. タイトルのとおり

## 理由

1. closes #1507 

## テスト

- ブラウザにて確認
