### PR TITLE
請求入力画面(B2C)の処理修正

### DIFF
--- a/packages/kokoas-client/src/pages/projInvoiceV2/api/convertInvoiceToForm.ts
+++ b/packages/kokoas-client/src/pages/projInvoiceV2/api/convertInvoiceToForm.ts
@@ -1,5 +1,5 @@
 import { IContracts, IInvoiceb2c, IProjects } from 'types';
-import { TForm, TInvoiceDetails } from '../schema';
+import { TForm } from '../schema';
 import { Big } from 'big.js';
 import { initInvDetailsValue } from '../form';
 import { sortContracts } from '../helper/sortContracts';
@@ -10,12 +10,10 @@ export const convertInvoiceToForm = ({
   invoiceRec,
   projectRec,
   contractRec,
-  invoiceId,
 }: {
   invoiceRec: IInvoiceb2c[] | undefined
   projectRec: IProjects
   contractRec: IContracts[]
-  invoiceId: string | undefined
 }): TForm => {
 
   const {
@@ -61,31 +59,6 @@ export const convertInvoiceToForm = ({
     .round()
     .toNumber();
 
-
-
-  const tgtInvRec = (() => {
-    if (!invoiceId) return {} as IInvoiceb2c;
-    invoiceRec?.find(({ uuid: invRecId }) => invRecId.value === invoiceId);
-  })();
-
-  const invoiceDetails: TInvoiceDetails = (() => {
-    if (!tgtInvRec) return [initInvDetailsValue];
-
-    return tgtInvRec?.invoiceDetails?.value.map(({
-      id,
-      value: {
-        billingAmountAfterTax,
-        invoiceItem,
-      },
-    }) => {
-      return ({
-        invoiceDetailId: id,
-        invoiceItem: invoiceItem.value,
-        billingAmount: +billingAmountAfterTax.value,
-      });
-    }) || [initInvDetailsValue];
-  })();
-
   const billedAmount = invoiceRec?.reduce((acc, {
     invoiceDetails: {
       value: invDetailsVal,
@@ -125,6 +98,6 @@ export const convertInvoiceToForm = ({
     remarks: '',
     paymentStatus: '',
 
-    invoiceDetails: invoiceDetails,
+    invoiceDetails: [initInvDetailsValue],
   };
 };

--- a/packages/kokoas-client/src/pages/projInvoiceV2/hooks/useResolveParams.ts
+++ b/packages/kokoas-client/src/pages/projInvoiceV2/hooks/useResolveParams.ts
@@ -53,7 +53,6 @@ export const useResolveParams = () => {
         projectRec: projData,
         contractRec: contractData,
         invoiceRec: invoicesB2CByProjId,
-        invoiceId: undefined,
       });
       setNewFormVal(newForm);
 
@@ -78,7 +77,6 @@ export const useResolveParams = () => {
         projectRec: projData,
         contractRec: contractData,
         invoiceRec: invoicesB2CByProjId,
-        invoiceId: invIdFromURL || undefined,
       });
       setNewFormVal({
         ...newForm,

--- a/packages/kokoas-client/src/pages/projInvoiceV2/sections/InputInvoice/InputSection/BillingAmount.tsx
+++ b/packages/kokoas-client/src/pages/projInvoiceV2/sections/InputInvoice/InputSection/BillingAmount.tsx
@@ -34,14 +34,17 @@ export const BillingAmount = ({
         return (
           <TextField
             {...otherValue}
-            value={value || ''}
+            value={value.toString() || ''}
             label={'請求金額(税込)'}
             size='small'
             error={!!error}
             helperText={error?.message}
             onChange={(e) => {
-              onChange(+e.target.value);
-              handleChange(+e.target.value, index);
+              const billingAmount = e.target.value;
+              if (!isNaN(+billingAmount)) {
+                onChange(+billingAmount);
+                handleChange(+billingAmount, index);
+              }
             }}
             required={required}
           />


### PR DESCRIPTION
## 変更

1. 請求金額に0が入力できない(表示されない)バグの修正
2. convertInvoiceToForm()から不要な処理を削除
3. 請求金額に数字以外を入れるとエラー終了する問題の対策

## 理由

1. closes #1513

## テスト

- ブラウザにて確認
